### PR TITLE
feat: WorkerEdu 엔티티 및 기록/조회 로직 구현

### DIFF
--- a/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
+++ b/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
@@ -1,0 +1,27 @@
+package com.iroom.management.controller;
+
+import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.WorkerEduResponse;
+import com.iroom.management.service.WorkerEduService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("workerEdu")
+@RequiredArgsConstructor
+public class WorkerEduController {
+    private final WorkerEduService workerEduService;
+
+    // 안전교육 이수 등록
+    @PostMapping("/record")
+    public WorkerEduResponse recordEdu(@RequestBody WorkerEduRequest requestDto) {
+        return workerEduService.recordEdu(requestDto);
+    }
+
+    // 교육 정보 조회
+    @GetMapping("/{workerId}")
+    public WorkerEduResponse getEduInfo(@PathVariable Long workerId) {
+        return workerEduService.getEduInfo(workerId);
+    }
+
+}

--- a/management/src/main/java/com/iroom/management/dto/request/WorkerEduRequest.java
+++ b/management/src/main/java/com/iroom/management/dto/request/WorkerEduRequest.java
@@ -1,0 +1,22 @@
+package com.iroom.management.dto.request;
+
+import com.iroom.management.entity.WorkerEdu;
+
+import java.time.LocalDate;
+
+public record WorkerEduRequest (
+        Long id,
+        Long workerId,
+        String name,
+        String certUrl,
+        LocalDate eduDate
+){
+    public WorkerEdu toEntity() {
+        return WorkerEdu.builder()
+                .workerId(workerId)
+                .name(name)
+                .certUrl(certUrl)
+                .eduDate(eduDate)
+                .build();
+    }
+}

--- a/management/src/main/java/com/iroom/management/dto/response/WorkerEduResponse.java
+++ b/management/src/main/java/com/iroom/management/dto/response/WorkerEduResponse.java
@@ -1,0 +1,25 @@
+package com.iroom.management.dto.response;
+
+import com.iroom.management.entity.WorkerEdu;
+
+import java.time.LocalDate;
+
+
+public record WorkerEduResponse (
+        Long id,
+        Long workerId,
+        String name,
+        String certUrl,
+        LocalDate eduDate
+){
+    // 엔티티 → DTO로 변환하는 생성자
+    public WorkerEduResponse(WorkerEdu entity) {
+        this(
+                entity.getId(),
+                entity.getWorkerId(),
+                entity.getName(),
+                entity.getCertUrl(),
+                entity.getEduDate()
+        );
+    }
+}

--- a/management/src/main/java/com/iroom/management/dto/response/WorkerManagementResponse.java
+++ b/management/src/main/java/com/iroom/management/dto/response/WorkerManagementResponse.java
@@ -1,5 +1,6 @@
 package com.iroom.management.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.iroom.management.entity.WorkerEdu;
 import com.iroom.management.entity.WorkerManagement;
 
@@ -9,7 +10,9 @@ import java.time.LocalDateTime;
 public record WorkerManagementResponse (
         Long id,
         Long workerId,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime enterDate,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime outDate
 ){
     public WorkerManagementResponse(WorkerManagement entity) {

--- a/management/src/main/java/com/iroom/management/entity/WorkerEdu.java
+++ b/management/src/main/java/com/iroom/management/entity/WorkerEdu.java
@@ -1,0 +1,31 @@
+package com.iroom.management.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "WorkerEdu_table")
+public class WorkerEdu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long workerId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String certUrl;
+
+    private LocalDate eduDate;
+}

--- a/management/src/main/java/com/iroom/management/entity/WorkerManagement.java
+++ b/management/src/main/java/com/iroom/management/entity/WorkerManagement.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 
 @Entity
 @Getter

--- a/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
+++ b/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
@@ -1,0 +1,10 @@
+package com.iroom.management.repository;
+
+
+import com.iroom.management.entity.WorkerEdu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WorkerEduRepository extends JpaRepository<WorkerEdu, Long> {
+}

--- a/management/src/main/java/com/iroom/management/service/WorkerEduService.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduService.java
@@ -1,0 +1,12 @@
+package com.iroom.management.service;
+
+import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.WorkerEduResponse;
+
+public interface WorkerEduService {
+    // 안전교육 내역 기록
+    WorkerEduResponse recordEdu(WorkerEduRequest requestDto);
+
+    // 안전교육 내역 조회
+    WorkerEduResponse getEduInfo(Long workerId);
+}

--- a/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
@@ -1,0 +1,31 @@
+package com.iroom.management.service;
+
+import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.WorkerEduResponse;
+import com.iroom.management.entity.WorkerEdu;
+import com.iroom.management.repository.WorkerEduRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WorkerEduServiceImpl implements WorkerEduService {
+
+    private final WorkerEduRepository workerEduRepository;
+
+    @Transactional
+    @Override
+    public WorkerEduResponse recordEdu(WorkerEduRequest requestDto) {
+        WorkerEdu workerEdu = requestDto.toEntity();
+        WorkerEdu saved = workerEduRepository.save(workerEdu);
+        return new WorkerEduResponse(saved);
+    }
+
+    @Override
+    public WorkerEduResponse getEduInfo(Long workerId) {
+        WorkerEdu edu = workerEduRepository.findById(workerId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 근로자의 교육 이력이 없습니다."));
+        return new WorkerEduResponse(edu);
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- 근로자 안전교육 내역을 등록하고 조회할 수 있는 기능을 추가했습니다.
- `WorkerEdu` 엔티티를 생성하여 교육일자(`eduDate`), 이름, 수료증 URL 등을 저장할 수 있도록 설계했습니다.
- 교육 등록 요청을 처리하는 `WorkerEduController`를 구현했습니다.
- 교육 등록 및 조회 로직을 담당하는 `WorkerEduService`, `WorkerEduServiceImpl`을 구성하였습니다.
- 교육일자는 `LocalDate`로 입력받으며, 날짜만 저장되도록 설계되었습니다.

---
## 테스트 결과
- 교육이수 등록
```
POST http://localhost:8080/workerEdu/record
Content-Type: application/json

{
  "workerId": 1,
  "name": "근로자1",
  "certUrl": "https://example.com/certificate/123.pdf",
  "eduDate": "2025-07-20"
}
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 22 Jul 2025 07:26:20 GMT

{
  "id": 1,
  "workerId": 1,
  "name": "근로자1",
  "certUrl": "https://example.com/certificate/123.pdf",
  "eduDate": "2025-07-20"
}
```
- 교육이수 조회
```
GET http://localhost:8080/workerEdu/1
Content-Type: application/json
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 22 Jul 2025 07:30:41 GMT

{
  "id": 1,
  "workerId": 1,
  "name": "근로자1",
  "certUrl": "https://example.com/certificate/123.pdf",
  "eduDate": "2025-07-20"
}
```
<img width="684" height="111" alt="image" src="https://github.com/user-attachments/assets/35a25f0a-072b-4c83-aaeb-a73bd5fd4e5c" />
