### PR TITLE
fix: workerId로 단건이 아닌 교육 이력 전체 조회하도록 수정

### DIFF
--- a/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
+++ b/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
@@ -8,6 +8,8 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("workerEdu")
 @RequiredArgsConstructor
@@ -23,8 +25,8 @@ public class WorkerEduController {
 
     // 교육 정보 조회
     @GetMapping("/{workerId}")
-    public ResponseEntity<WorkerEduResponse> getEduInfo(@PathVariable Long workerId) {
-        WorkerEduResponse response = workerEduService.getEduInfo(workerId);
+    public ResponseEntity<List<WorkerEduResponse>> getEduInfo(@PathVariable Long workerId) {
+        List<WorkerEduResponse> response = workerEduService.getEduInfo(workerId);
         return ResponseEntity.ok(response);
     }
 

--- a/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
+++ b/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
@@ -5,6 +5,9 @@ import com.iroom.management.entity.WorkerEdu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface WorkerEduRepository extends JpaRepository<WorkerEdu, Long> {
+    List<WorkerEdu> findByWorkerId(Long workerId);
 }

--- a/management/src/main/java/com/iroom/management/service/WorkerEduService.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduService.java
@@ -3,10 +3,12 @@ package com.iroom.management.service;
 import com.iroom.management.dto.request.WorkerEduRequest;
 import com.iroom.management.dto.response.WorkerEduResponse;
 
+import java.util.List;
+
 public interface WorkerEduService {
     // 안전교육 내역 기록
     WorkerEduResponse recordEdu(WorkerEduRequest requestDto);
 
     // 안전교육 내역 조회
-    WorkerEduResponse getEduInfo(Long workerId);
+    List<WorkerEduResponse> getEduInfo(Long workerId);
 }

--- a/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
@@ -8,6 +8,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class WorkerEduServiceImpl implements WorkerEduService {
@@ -23,9 +25,13 @@ public class WorkerEduServiceImpl implements WorkerEduService {
     }
 
     @Override
-    public WorkerEduResponse getEduInfo(Long workerId) {
-        WorkerEdu edu = workerEduRepository.findById(workerId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 근로자의 교육 이력이 없습니다."));
-        return new WorkerEduResponse(edu);
+    public List<WorkerEduResponse> getEduInfo(Long workerId) {
+        List<WorkerEdu> eduList = workerEduRepository.findByWorkerId(workerId);
+        if (eduList.isEmpty()) {
+            throw new IllegalArgumentException("해당 근로자의 교육 이력이 없습니다.");
+        }
+        return eduList.stream()
+                .map(WorkerEduResponse::new)
+                .toList();
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- 기존에는 workerId로 교육 이력을 조회할 때 findById()를 사용하여 단건만 조회되던 문제를 수정하였습니다.
- WorkerEduService 및 WorkerEduController에서 workerId에 해당하는 모든 교육 이력을 조회하도록 로직을 변경하였습니다.
- WorkerEduResponse를 리스트 형태로 반환하도록 API 응답 구조를 변경하였습니다.

---
## 테스트 결과
- 근로자1의 교육이수내역 다건일 경우
<img width="695" height="108" alt="image" src="https://github.com/user-attachments/assets/c65b822d-6704-42fa-9e27-a1d573bf4215" />

```
GET http://localhost:8080/workerEdu/1
Content-Type: application/json
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Wed, 23 Jul 2025 01:02:40 GMT

[
  {
    "id": 1,
    "workerId": 1,
    "name": "근로자1",
    "certUrl": "https://example.com/certificate/123.pdf",
    "eduDate": "2025-07-20"
  },
  {
    "id": 2,
    "workerId": 1,
    "name": "근로자1",
    "certUrl": "https://example.com/certificate/456.pdf",
    "eduDate": "2025-07-23"
  }
]
```