### PR TITLE
feat: 대시보드 기능 구현

### DIFF
--- a/dashboard/build.gradle
+++ b/dashboard/build.gradle
@@ -36,9 +36,11 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    //추가한 의존성
+    implementation 'com.itextpdf:itextpdf:5.5.13.2'// (pdf로 만들어주는 라이브러리)
     // Database
-    runtimeOnly 'com.h2database:h2'
-
+    //runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j' //mysql로 변경
     // Test Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.cucumber:cucumber-java:7.14.1'

--- a/dashboard/src/main/java/iroom/controller/DashBoardController.java
+++ b/dashboard/src/main/java/iroom/controller/DashBoardController.java
@@ -13,22 +13,21 @@ import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value="/dashBoards")
+@RequestMapping(value="/dashboards")
 public class DashBoardController {
     private final DashBoardService dashBoardService;
 
     private final PdfService pdfService;
     //대시보드 조회하기
-    @GetMapping (value ="/get-DashBoard", produces = "application/json;charset=UTF-8")
-    public ResponseEntity<DashBoardResponse> getDashBoard(@RequestParam("metricType")String metricType){
+    @GetMapping (value ="/{metricType}", produces = "application/json;charset=UTF-8")
+    public ResponseEntity<DashBoardResponse> getDashBoard(@PathVariable String metricType){
         DashBoardResponse dashBoardDto= dashBoardService.getDashBoard(metricType);
         return ResponseEntity.ok(dashBoardDto);
     }
 
-
-    @GetMapping(
-            value = "/export-report",
-            produces = "application/json;charset=UTF-8"
+    //리포트 생성
+    @PostMapping(
+            value = "/report"
     )
     public ResponseEntity<byte[]> exportReport() throws Exception {
         LocalDate currentDate = LocalDate.now();
@@ -41,9 +40,9 @@ public class DashBoardController {
         return ResponseEntity.ok().headers(headers).body(pdfBytes);
     }
 
-    @GetMapping(
-            value = "/create-improvement",
-            produces = "application/json;charset=UTF-8"
+    //개선안 생성
+    @PostMapping(
+            value = "/improvement-report"
     )
     public ResponseEntity<byte[]> createImprovement(
     ) throws Exception {

--- a/dashboard/src/main/java/iroom/controller/DashBoardController.java
+++ b/dashboard/src/main/java/iroom/controller/DashBoardController.java
@@ -1,0 +1,60 @@
+package iroom.controller;
+
+
+
+import iroom.dto.DashBoardResponse;
+import iroom.service.DashBoardService;
+import iroom.service.PdfService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value="/api")
+public class DashBoardController {
+    private final DashBoardService dashBoardService;
+
+    private final PdfService pdfService;
+    //대시보드 조회하기
+    @GetMapping (value ="/dashBoards/getDashBoard", produces = "application/json;charset=UTF-8")
+    public ResponseEntity<DashBoardResponse> getDashBoard(@RequestParam("metricType")String metricType){
+        DashBoardResponse dashBoardDto= dashBoardService.getDashBoard(metricType);
+        return new ResponseEntity<>(dashBoardDto, HttpStatus.OK);
+    }
+
+
+    @GetMapping(
+            value = "/dashBoards/exportreport",
+            produces = "application/json;charset=UTF-8"
+    )
+    public ResponseEntity<byte[]> exportReport() throws Exception {
+        LocalDate currentDate = LocalDate.now();
+        byte[] pdfBytes = pdfService.generateDashboardPdf("report_"+currentDate);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentDisposition(ContentDisposition.builder("attachment")
+                .filename("report_"+currentDate+".pdf") //
+                .build());
+        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+    }
+
+    @GetMapping(
+            value = "/dashBoards/createimprovement",
+            produces = "application/json;charset=UTF-8"
+    )
+    public ResponseEntity<byte[]> createImprovement(
+    ) throws Exception {
+        LocalDate currentDate = LocalDate.now();
+        byte[] pdfBytes = pdfService.generateDashboardPdf("improvement_report_"+currentDate);
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentDisposition(ContentDisposition.builder("attachment")
+                .filename("improvement_report_"+currentDate+".pdf")
+                .build());
+        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+    }
+}

--- a/dashboard/src/main/java/iroom/controller/DashBoardController.java
+++ b/dashboard/src/main/java/iroom/controller/DashBoardController.java
@@ -13,21 +13,21 @@ import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value="/api")
+@RequestMapping(value="/dashBoards")
 public class DashBoardController {
     private final DashBoardService dashBoardService;
 
     private final PdfService pdfService;
     //대시보드 조회하기
-    @GetMapping (value ="/dashBoards/getDashBoard", produces = "application/json;charset=UTF-8")
+    @GetMapping (value ="/get-DashBoard", produces = "application/json;charset=UTF-8")
     public ResponseEntity<DashBoardResponse> getDashBoard(@RequestParam("metricType")String metricType){
         DashBoardResponse dashBoardDto= dashBoardService.getDashBoard(metricType);
-        return new ResponseEntity<>(dashBoardDto, HttpStatus.OK);
+        return ResponseEntity.ok(dashBoardDto);
     }
 
 
     @GetMapping(
-            value = "/dashBoards/exportreport",
+            value = "/export-report",
             produces = "application/json;charset=UTF-8"
     )
     public ResponseEntity<byte[]> exportReport() throws Exception {
@@ -38,11 +38,11 @@ public class DashBoardController {
         headers.setContentDisposition(ContentDisposition.builder("attachment")
                 .filename("report_"+currentDate+".pdf") //
                 .build());
-        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+        return ResponseEntity.ok().headers(headers).body(pdfBytes);
     }
 
     @GetMapping(
-            value = "/dashBoards/createimprovement",
+            value = "/create-improvement",
             produces = "application/json;charset=UTF-8"
     )
     public ResponseEntity<byte[]> createImprovement(
@@ -55,6 +55,6 @@ public class DashBoardController {
         headers.setContentDisposition(ContentDisposition.builder("attachment")
                 .filename("improvement_report_"+currentDate+".pdf")
                 .build());
-        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+        return ResponseEntity.ok().headers(headers).body(pdfBytes);
     }
 }

--- a/dashboard/src/main/java/iroom/dto/DashBoardResponse.java
+++ b/dashboard/src/main/java/iroom/dto/DashBoardResponse.java
@@ -1,0 +1,9 @@
+package iroom.dto;
+
+import java.time.LocalDateTime;
+
+public record DashBoardResponse(
+        String metricType,
+        Integer metricValue,
+        LocalDateTime recordedAt
+) {}

--- a/dashboard/src/main/java/iroom/entity/DashBoard.java
+++ b/dashboard/src/main/java/iroom/entity/DashBoard.java
@@ -1,0 +1,34 @@
+package iroom.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DashBoard {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private  Long id;
+
+    @Column
+    private String metricType;
+
+    @Column
+    private Integer metricValue;
+
+    @Column
+    private LocalDateTime recordedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.recordedAt = LocalDateTime.now();
+    }
+}

--- a/dashboard/src/main/java/iroom/repository/DashBoardRepository.java
+++ b/dashboard/src/main/java/iroom/repository/DashBoardRepository.java
@@ -1,0 +1,14 @@
+package iroom.repository;
+
+
+import iroom.entity.DashBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+
+@Repository
+public interface DashBoardRepository extends JpaRepository<DashBoard, Long> {
+    DashBoard findTopByMetricTypeOrderByIdDesc(String metricType);
+
+}

--- a/dashboard/src/main/java/iroom/service/DashBoardService.java
+++ b/dashboard/src/main/java/iroom/service/DashBoardService.java
@@ -1,0 +1,32 @@
+package iroom.service;
+
+
+
+
+import iroom.dto.DashBoardResponse;
+import iroom.entity.DashBoard;
+import iroom.repository.DashBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class DashBoardService {
+    private final DashBoardRepository dashBoardRepository;
+    public DashBoardResponse getDashBoard(String metricType){
+
+        DashBoard dashBoard= dashBoardRepository.findTopByMetricTypeOrderByIdDesc(metricType);
+
+        DashBoardResponse dashBoardDto = new DashBoardResponse(
+                dashBoard.getMetricType(),
+                dashBoard.getMetricValue(),
+                dashBoard.getRecordedAt()
+        );
+
+
+        return dashBoardDto;
+    }
+
+}

--- a/dashboard/src/main/java/iroom/service/DashBoardService.java
+++ b/dashboard/src/main/java/iroom/service/DashBoardService.java
@@ -19,14 +19,14 @@ public class DashBoardService {
 
         DashBoard dashBoard= dashBoardRepository.findTopByMetricTypeOrderByIdDesc(metricType);
 
-        DashBoardResponse dashBoardDto = new DashBoardResponse(
+        DashBoardResponse dashBoardResponse = new DashBoardResponse(
                 dashBoard.getMetricType(),
                 dashBoard.getMetricValue(),
                 dashBoard.getRecordedAt()
         );
 
 
-        return dashBoardDto;
+        return dashBoardResponse;
     }
 
 }

--- a/dashboard/src/main/java/iroom/service/PdfService.java
+++ b/dashboard/src/main/java/iroom/service/PdfService.java
@@ -1,0 +1,66 @@
+package iroom.service;
+
+
+
+import com.itextpdf.text.*;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+import iroom.entity.DashBoard;
+import iroom.repository.DashBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class PdfService {
+
+    private final DashBoardRepository dashBoardRepository;
+
+    public byte[] generateDashboardPdf(String pdfTitle) throws DocumentException {
+        List<DashBoard> dashboards = dashBoardRepository.findAll();
+
+        Document document = new Document();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        PdfWriter.getInstance(document, out);
+        document.open();
+
+        Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+        Font bodyFont = FontFactory.getFont(FontFactory.HELVETICA, 12);
+
+        Paragraph title = new Paragraph(pdfTitle, headerFont);
+        title.setAlignment(Element.ALIGN_CENTER);
+        title.setSpacingAfter(20f);
+        document.add(title);
+
+        PdfPTable table = new PdfPTable(4); // id, metricType, metricValue, recordedAt
+        table.setWidthPercentage(100);
+        table.setWidths(new int[]{1, 3, 2, 3});
+
+        // Table Header
+        Stream.of("ID", "Metric Type", "Metric Value", "Recorded At").forEach(col -> {
+            PdfPCell header = new PdfPCell(new Phrase(col, headerFont));
+            header.setHorizontalAlignment(Element.ALIGN_CENTER);
+            header.setBackgroundColor(BaseColor.LIGHT_GRAY);
+            table.addCell(header);
+        });
+
+        // Table Rows
+        for (DashBoard d : dashboards) {
+            table.addCell(new PdfPCell(new Phrase(d.getId().toString(), bodyFont)));
+            table.addCell(new PdfPCell(new Phrase(d.getMetricType(), bodyFont)));
+            table.addCell(new PdfPCell(new Phrase(d.getMetricValue().toString(), bodyFont)));
+            table.addCell(new PdfPCell(new Phrase(d.getRecordedAt().toString(), bodyFont)));
+        }
+
+        document.add(table);
+        document.close();
+
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
## ✨ 주요 기능
* 대시보드 Entity 및 DTO 정의

* DashBoard JPA 엔티티 생성

* Java record를 활용한 DashBoardResponse DTO 정의

* 가장 최신 MetricType 조회 로직 구현

* 가장 최근에 기록된 메트릭 타입을 조회하는 서비스 및 레포지토리 로직 추가

* 텍스트 → PDF 변환 기능 추가

* iText 라이브러리(v5.5.13.2)를 활용한 PDF 생성 기능 구현

* PdfService를 통해 개선사항을 PDF로 저장 가능

* REST 컨트롤러 구현

* 대시보드 메트릭을 조회하고 개선 리포트를 생성하는 API 추가

* DB 연동 및 설정

* 데이터베이스를 MySQL로 변경

* PDF 저장 경로 또는 관련 정보 DB에 저장 (해당 기능이 있다면)

## DB 목록
<img width="501" height="225" alt="image" src="https://github.com/user-attachments/assets/93d33f2a-4961-45f6-a84f-b849fe08bea0" />

## 테스트 결과
<img width="1014" height="466" alt="image" src="https://github.com/user-attachments/assets/51e202b8-111b-4db5-bdb7-7276e9f5b075" />

