### PR TITLE
feat: DangerArea 엔티티 및 CRUD 로직 구현

### DIFF
--- a/dashboard/src/main/java/com/iroom/dashboard/controller/DangerAreaController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/controller/DangerAreaController.java
@@ -1,0 +1,39 @@
+package com.iroom.dashboard.controller;
+
+import com.iroom.dashboard.dto.request.DangerAreaRequest;
+import com.iroom.dashboard.dto.response.DangerAreaResponse;
+import com.iroom.dashboard.service.DangerAreaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/dangerAreas")
+@RequiredArgsConstructor
+public class DangerAreaController {
+    private final DangerAreaService dangerAreaService;
+
+    @PostMapping
+    public ResponseEntity<DangerAreaResponse> create(@RequestBody DangerAreaRequest request) {
+        return ResponseEntity.ok(dangerAreaService.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DangerAreaResponse> update(@PathVariable Long id, @RequestBody DangerAreaRequest request) {
+        return ResponseEntity.ok(dangerAreaService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> delete(@PathVariable Long id) {
+        dangerAreaService.delete(id);
+        return ResponseEntity.ok(Map.of("message", "위험구역 삭제 완료", "deletedId", id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<DangerAreaResponse>> getAll() {
+        return ResponseEntity.ok(dangerAreaService.getAll());
+    }
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/request/DangerAreaRequest.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/request/DangerAreaRequest.java
@@ -1,0 +1,9 @@
+package com.iroom.dashboard.dto.request;
+
+public record DangerAreaRequest (
+        Long blueprintId,
+        String location,
+        Double width,
+        Double height
+){
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/response/DangerAreaResponse.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/response/DangerAreaResponse.java
@@ -1,0 +1,21 @@
+package com.iroom.dashboard.dto.response;
+
+import com.iroom.dashboard.entity.DangerArea;
+
+public record DangerAreaResponse (
+        Long id,
+        Long blueprintId,
+        String location,
+        Double width,
+        Double height
+){
+    public DangerAreaResponse(DangerArea entity) {
+        this(
+                entity.getId(),
+                entity.getBlueprintId(),
+                entity.getLocation(),
+                entity.getWidth(),
+                entity.getHeight()
+        );
+    }
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
@@ -1,0 +1,36 @@
+package com.iroom.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "DangerArea")
+public class DangerArea {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private Long blueprintId;
+
+    private String location;
+
+    private Double width;
+
+    private Double height;
+
+    @Builder
+    public DangerArea (Long blueprintId, String location, Double width, Double height){
+        this.blueprintId = blueprintId;
+        this.location = location;
+        this.width = width;
+        this.height = height;
+    }
+
+    public void update(String location, Double width, Double height){
+        this.location = location;
+        this.width = width;
+        this.height = height;
+    }
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
@@ -12,12 +12,16 @@ public class DangerArea {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @Column(nullable = false)
     private Long blueprintId;
 
+    @Column(nullable = false)
     private String location;
 
+    @Column(nullable = false)
     private Double width;
 
+    @Column(nullable = false)
     private Double height;
 
     @Builder

--- a/dashboard/src/main/java/com/iroom/dashboard/repository/DangerAreaRepository.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/repository/DangerAreaRepository.java
@@ -1,0 +1,9 @@
+package com.iroom.dashboard.repository;
+
+import com.iroom.dashboard.entity.DangerArea;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DangerAreaRepository extends JpaRepository<DangerArea, Long> {
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaService.java
@@ -1,0 +1,21 @@
+package com.iroom.dashboard.service;
+
+import com.iroom.dashboard.dto.request.DangerAreaRequest;
+import com.iroom.dashboard.dto.response.DangerAreaResponse;
+
+import java.util.List;
+
+public interface DangerAreaService {
+
+    // 위험구역 등록
+    DangerAreaResponse create(DangerAreaRequest request);
+
+    // 위험구역 수정
+    DangerAreaResponse update(Long id, DangerAreaRequest request);
+
+    // 위험구역 삭제
+    void delete(Long id);
+
+    // 위험구역 조회
+    List<DangerAreaResponse> getAll();
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaServiceImpl.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaServiceImpl.java
@@ -1,0 +1,57 @@
+package com.iroom.dashboard.service;
+
+import com.iroom.dashboard.dto.request.DangerAreaRequest;
+import com.iroom.dashboard.dto.response.DangerAreaResponse;
+import com.iroom.dashboard.entity.DangerArea;
+import com.iroom.dashboard.repository.DangerAreaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DangerAreaServiceImpl implements DangerAreaService {
+
+    private final DangerAreaRepository dangerAreaRepository;
+
+    @Transactional
+    @Override
+    public DangerAreaResponse create(DangerAreaRequest request) {
+        DangerArea dangerArea = DangerArea.builder()
+                .blueprintId(request.blueprintId())
+                .location(request.location())
+                .width(request.width())
+                .height(request.height())
+                .build();
+        return new DangerAreaResponse(dangerAreaRepository.save(dangerArea));
+    }
+
+    @Transactional
+    @Override
+    public DangerAreaResponse update(Long id, DangerAreaRequest request) {
+        DangerArea dangerArea = dangerAreaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 위험구역이 존재하지 않습니다."));
+        dangerArea.update(request.location(), request.width(), request.height());
+        return new DangerAreaResponse(dangerArea);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Long id) {
+        if (!dangerAreaRepository.existsById(id)) {
+            throw new IllegalArgumentException("해당 위험구역이 존재하지 않습니다.");
+        }
+        dangerAreaRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<DangerAreaResponse> getAll() {
+        return dangerAreaRepository.findAll()
+                .stream()
+                .map(DangerAreaResponse::new)
+                .toList();
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- 위험 구역 정보를 등록/수정/삭제/조회할 수 있는 기능을 추가했습니다.
- `DangerArea` 엔티티를 생성하여 도면 ID(blueprintId), 위치(location), 넓이(width), 높이(height) 정보를 저장하도록 설계했습니다.
- 위험 구역 등록/수정/삭제 요청을 처리하는 `DangerAreaController`를 구현했습니다.
- 비즈니스 로직을 수행하는 `DangerAreaService`, `DangerAreaServiceImpl`을 구현하였으며, `update()`는 도메인 내부에서 상태를 변경하는 방식으로 구성했습니다. (다른 서비스도 동일한 방식으로 개선할 예정입니다.)

---
## 테스트 결과
- 위험구역 등록
```
POST http://localhost:8080/dangerAreas
Content-Type: application/json

{
  "blueprintId": 1,
  "location": "X:100,Y:150",
  "width": 3.5,
  "height": 2.8
}
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 24 Jul 2025 02:23:00 GMT

{
  "id": 1,
  "blueprintId": 1,
  "location": "X:100,Y:150",
  "width": 3.5,
  "height": 2.8
}
```

- 위험구역 수정
```
PUT http://localhost:8080/dangerAreas/1
Content-Type: application/json

{
  "location": "X:200,Y:180",
  "width": 4.0,
  "height": 3.0
}
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 24 Jul 2025 02:23:20 GMT

{
  "id": 1,
  "blueprintId": 1,
  "location": "X:200,Y:180",
  "width": 4.0,
  "height": 3.0
}
```

- 위험구역 삭제
```
DELETE http://localhost:8080/dangerAreas/1
Content-Type: application/json
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 24 Jul 2025 02:23:34 GMT

{
  "deletedId": 1,
  "message": "위험구역 삭제 완료"
}
```