### PR TITLE
refactor: 고객관리, 도면, 알람 도메인 테이블명 및 엔티티 필드/로직 통일 리팩토링

### DIFF
--- a/alarm/src/main/java/com/iroom/alarm/entity/Alarm.java
+++ b/alarm/src/main/java/com/iroom/alarm/entity/Alarm.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "Alarm_table")
+@Table(name = "Alarm")
 public class Alarm {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/alarm/src/main/java/com/iroom/alarm/entity/Alarm.java
+++ b/alarm/src/main/java/com/iroom/alarm/entity/Alarm.java
@@ -8,8 +8,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Table(name = "Alarm")
 public class Alarm {
     @Id
@@ -34,5 +32,13 @@ public class Alarm {
     @PrePersist
     public void prePersist() {
         this.occuredAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Alarm(Long workerId, String incidentType, Long incidentId, String incidentDescription) {
+        this.workerId = workerId;
+        this.incidentType = incidentType;
+        this.incidentId = incidentId;
+        this.incidentDescription = incidentDescription;
     }
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/entity/Blueprint.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/entity/Blueprint.java
@@ -6,9 +6,7 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
-@Table(name = "Blueprint_table")
+@Table(name = "Blueprint")
 public class Blueprint {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -25,4 +23,19 @@ public class Blueprint {
 
     @Column(nullable = false)
     private Double height;
+
+    @Builder
+    public Blueprint (String blueprintUrl, Integer floor, Double width, Double height) {
+        this.blueprintUrl =  blueprintUrl;
+        this.floor = floor;
+        this.width = width;
+        this.height = height;
+    }
+
+    public void update(String blueprintUrl, Integer floor, Double width, Double height) {
+        this.blueprintUrl = blueprintUrl;
+        this.floor = floor;
+        this.width = width;
+        this.height = height;
+    }
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintServiceImpl.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintServiceImpl.java
@@ -33,16 +33,8 @@ public class BlueprintServiceImpl implements BlueprintService {
     public BlueprintResponse updateBlueprint(Long id, BlueprintRequest request) {
         Blueprint blueprint = blueprintRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 도면이 존재하지 않습니다."));
-
-        Blueprint updated = Blueprint.builder()
-                .id(blueprint.getId())
-                .blueprintUrl(request.blueprintUrl())
-                .floor(request.floor())
-                .width(request.width())
-                .height(request.height())
-                .build();
-
-        return new BlueprintResponse(blueprintRepository.save(updated));
+        blueprint.update(request.blueprintUrl(), request.floor(), request.width(), request.height());
+        return new BlueprintResponse(blueprint);
     }
 
     @Transactional

--- a/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
+++ b/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
@@ -4,14 +4,13 @@ import com.iroom.management.dto.request.WorkerEduRequest;
 import com.iroom.management.dto.response.WorkerEduResponse;
 import com.iroom.management.service.WorkerEduService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("workerEdu")
+@RequestMapping("/workerEdu")
 @RequiredArgsConstructor
 public class WorkerEduController {
     private final WorkerEduService workerEduService;

--- a/management/src/main/java/com/iroom/management/controller/WorkerManagementController.java
+++ b/management/src/main/java/com/iroom/management/controller/WorkerManagementController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("workerManagement")
+@RequestMapping("/workerManagement")
 @RequiredArgsConstructor
 public class WorkerManagementController {
     private final WorkerManagementService workerManagementService;

--- a/management/src/main/java/com/iroom/management/dto/response/WorkerManagementResponse.java
+++ b/management/src/main/java/com/iroom/management/dto/response/WorkerManagementResponse.java
@@ -1,7 +1,6 @@
 package com.iroom.management.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.iroom.management.entity.WorkerEdu;
 import com.iroom.management.entity.WorkerManagement;
 
 import java.time.LocalDateTime;

--- a/management/src/main/java/com/iroom/management/entity/WorkerEdu.java
+++ b/management/src/main/java/com/iroom/management/entity/WorkerEdu.java
@@ -1,7 +1,7 @@
 package com.iroom.management.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +10,8 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-@Table(name = "WorkerEdu_table")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "WorkerEdu")
 public class WorkerEdu {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +23,17 @@ public class WorkerEdu {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     private String certUrl;
 
+    @Column(nullable = false)
     private LocalDate eduDate;
+
+    @Builder
+    public WorkerEdu(Long workerId, String name, String certUrl, LocalDate eduDate) {
+        this.workerId = workerId;
+        this.name = name;
+        this.certUrl = certUrl;
+        this.eduDate = eduDate;
+    }
 }

--- a/management/src/main/java/com/iroom/management/entity/WorkerManagement.java
+++ b/management/src/main/java/com/iroom/management/entity/WorkerManagement.java
@@ -1,16 +1,17 @@
 package com.iroom.management.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
-@Table(name = "WorkerManagement_table")
+@Table(name = "WorkerManagement")
 public class WorkerManagement {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -30,5 +31,10 @@ public class WorkerManagement {
 
     public void markExitedNow(){
         this.outDate = LocalDateTime.now();
+    }
+
+    @Builder
+    public WorkerManagement(Long workerId){
+        this.workerId = workerId;
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 리팩토링
---

## 변경 사항
- 엔티티 클래스의 테이블명을 *_table에서 도메인 이름과 동일한 형식(Alarm, WorkerEdu, WorkerManagement, Blueprint)으로 통일하였습니다.
- `WorkerEdu` 엔티티의 `certUrl`, `eduDate` 필드에 `nullable = false` 제약 조건을 추가하여, 필수값으로 명시하였습니다. 
- 사용되지 않는 불필요한 import 구문을 정리하였습니다.
- 엔티티의 `@AllArgsConstructor`를 제거하고, 필요한 경우 명시적인 생성자에 `@Builder`를 적용하도록 변경하였습니다.
- Builder를 사용해 객체를 새로 생성하던 기존 업데이트 로직을 도메인 내부의 `update()` 메서드를 통해 필드 값을 직접 변경하는 방식으로 개선하였습니다.
---
