### PR TITLE
feat: 근로자 교육 이력 조회에 페이징 기능 추가

### DIFF
--- a/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
+++ b/management/src/main/java/com/iroom/management/controller/WorkerEduController.java
@@ -1,6 +1,7 @@
 package com.iroom.management.controller;
 
 import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.PagedResponse;
 import com.iroom.management.dto.response.WorkerEduResponse;
 import com.iroom.management.service.WorkerEduService;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,15 @@ public class WorkerEduController {
 
     // 교육 정보 조회
     @GetMapping("/workers/{workerId}")
-    public ResponseEntity<List<WorkerEduResponse>> getEduInfo(@PathVariable Long workerId) {
-        List<WorkerEduResponse> response = workerEduService.getEduInfo(workerId);
+    public ResponseEntity<PagedResponse<WorkerEduResponse>> getEduInfo(
+            @PathVariable Long workerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        if (size > 50) size = 50;
+        if (size < 0) size = 0;
+
+        PagedResponse<WorkerEduResponse> response = workerEduService.getEduInfo(workerId, page, size);
         return ResponseEntity.ok(response);
     }
 

--- a/management/src/main/java/com/iroom/management/dto/response/PagedResponse.java
+++ b/management/src/main/java/com/iroom/management/dto/response/PagedResponse.java
@@ -1,0 +1,23 @@
+package com.iroom.management.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PagedResponse<T>(
+        List<T> content,
+        Integer page,
+        Integer size,
+        Long totalElements,
+        Integer totalPages,
+        Boolean first,
+        Boolean last
+) {
+    public PagedResponse(Page<T> page) {
+        this(page.getContent(), page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages(), page.isFirst(), page.isLast());
+    }
+
+    public static <T> PagedResponse<T> of(Page<T> page) {
+        return new PagedResponse<>(page);
+    }
+}

--- a/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
+++ b/management/src/main/java/com/iroom/management/repository/WorkerEduRepository.java
@@ -2,6 +2,8 @@ package com.iroom.management.repository;
 
 
 import com.iroom.management.entity.WorkerEdu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +11,5 @@ import java.util.List;
 
 @Repository
 public interface WorkerEduRepository extends JpaRepository<WorkerEdu, Long> {
-    List<WorkerEdu> findByWorkerId(Long workerId);
+    Page<WorkerEdu> findAllByWorkerId(Long workerId, Pageable pageable);
 }

--- a/management/src/main/java/com/iroom/management/service/WorkerEduService.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduService.java
@@ -1,6 +1,7 @@
 package com.iroom.management.service;
 
 import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.PagedResponse;
 import com.iroom.management.dto.response.WorkerEduResponse;
 
 import java.util.List;
@@ -10,5 +11,5 @@ public interface WorkerEduService {
     WorkerEduResponse recordEdu(WorkerEduRequest requestDto);
 
     // 안전교육 내역 조회
-    List<WorkerEduResponse> getEduInfo(Long workerId);
+    PagedResponse<WorkerEduResponse> getEduInfo(Long workerId, int page, int size);
 }

--- a/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
+++ b/management/src/main/java/com/iroom/management/service/WorkerEduServiceImpl.java
@@ -1,11 +1,15 @@
 package com.iroom.management.service;
 
 import com.iroom.management.dto.request.WorkerEduRequest;
+import com.iroom.management.dto.response.PagedResponse;
 import com.iroom.management.dto.response.WorkerEduResponse;
 import com.iroom.management.entity.WorkerEdu;
 import com.iroom.management.repository.WorkerEduRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,13 +29,12 @@ public class WorkerEduServiceImpl implements WorkerEduService {
     }
 
     @Override
-    public List<WorkerEduResponse> getEduInfo(Long workerId) {
-        List<WorkerEdu> eduList = workerEduRepository.findByWorkerId(workerId);
-        if (eduList.isEmpty()) {
-            throw new IllegalArgumentException("해당 근로자의 교육 이력이 없습니다.");
-        }
-        return eduList.stream()
-                .map(WorkerEduResponse::new)
-                .toList();
+    public PagedResponse<WorkerEduResponse> getEduInfo(Long workerId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<WorkerEdu> eduPage = workerEduRepository.findAllByWorkerId(workerId, pageable);
+
+        Page<WorkerEduResponse> responsePage = eduPage.map(WorkerEduResponse::new);
+
+        return PagedResponse.of(responsePage);
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- user 모듈의 `PagedResponse` 클래스를 `management` 모듈에 복사하여 재사용하도록 구조 개선
- `WorkerEduController`에서 교육 이력 조회 API에 페이징 기능 적용 
- 서비스 계층 및 레포지토리 로직을 Pageable 기반으로 수정하여 대용량 데이터 대응
- 기본 page, size 파라미터 값 지정 (0, 10) 및 최대 사이즈 제한 (50) 로직 추가
- `RequestParam(required = false) String target, String keyword` 는 현재 필터 조건이 불필요하다고 판단하여 제외함
---
## 테스트 결과
```
GET http://localhost:8080/worker-education/workers/1?page=0&size=5
```
```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 25 Jul 2025 06:26:16 GMT

{
  "content": [
    {
      "id": 1,
      "workerId": 1,
      "name": "근로자1",
      "certUrl": "https://example.com/certificate/123.pdf",
      "eduDate": "2025-07-23"
    },
    {
      "id": 2,
      "workerId": 1,
      "name": "근로자1",
      "certUrl": "https://example.com/certificate/123.pdf",
      "eduDate": "2025-07-23"
    }
  ],
  "page": 0,
  "size": 5,
  "totalElements": 2,
  "totalPages": 1,
  "first": true,
  "last": true
}
```