### PR TITLE
feat: Blueprint 테스트 코드 추가

### DIFF
--- a/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
@@ -4,7 +4,9 @@ import com.iroom.dashboard.dto.request.BlueprintRequest;
 import com.iroom.dashboard.dto.response.BlueprintResponse;
 import com.iroom.dashboard.dto.response.PagedResponse;
 import com.iroom.dashboard.service.BlueprintService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,40 +17,42 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BlueprintController {
 
-    private final BlueprintService blueprintService;
+	private final BlueprintService blueprintService;
 
-    // 도면 등록
-    @PostMapping
-    public ResponseEntity<BlueprintResponse> createBlueprint(@RequestBody BlueprintRequest request) {
-        BlueprintResponse response = blueprintService.createBlueprint(request);
-        return ResponseEntity.ok(response);
-    }
+	// 도면 등록
+	@PostMapping
+	public ResponseEntity<BlueprintResponse> createBlueprint(@RequestBody BlueprintRequest request) {
+		BlueprintResponse response = blueprintService.createBlueprint(request);
+		return ResponseEntity.ok(response);
+	}
 
-    // 도면 수정
-    @PutMapping("/{id}")
-    public ResponseEntity<BlueprintResponse> updateBlueprint(@PathVariable Long id,
-                                                                @RequestBody BlueprintRequest request) {
-        BlueprintResponse response = blueprintService.updateBlueprint(id, request);
-        return ResponseEntity.ok(response);
-    }
+	// 도면 수정
+	@PutMapping("/{id}")
+	public ResponseEntity<BlueprintResponse> updateBlueprint(@PathVariable Long id,
+		@RequestBody BlueprintRequest request) {
+		BlueprintResponse response = blueprintService.updateBlueprint(id, request);
+		return ResponseEntity.ok(response);
+	}
 
-    // 도면 삭제
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, Object>> deleteBlueprint(@PathVariable Long id) {
-        blueprintService.deleteBlueprint(id);
-        return ResponseEntity.ok(Map.of("message", "도면 삭제 완료", "deletedId", id));
-    }
+	// 도면 삭제
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Map<String, Object>> deleteBlueprint(@PathVariable Long id) {
+		blueprintService.deleteBlueprint(id);
+		return ResponseEntity.ok(Map.of("message", "도면 삭제 완료", "deletedId", id));
+	}
 
-    // 도면 전체 조회
-    @GetMapping
-    public ResponseEntity<PagedResponse<BlueprintResponse>> getAllBlueprints(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        if (size > 50) size = 50;
-        if (size < 0) size = 0;
+	// 도면 전체 조회
+	@GetMapping
+	public ResponseEntity<PagedResponse<BlueprintResponse>> getAllBlueprints(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		if (size > 50)
+			size = 50;
+		if (size < 0)
+			size = 0;
 
-        PagedResponse<BlueprintResponse> responses = blueprintService.getAllBlueprints(page, size);
-        return ResponseEntity.ok(responses);
-    }
+		PagedResponse<BlueprintResponse> responses = blueprintService.getAllBlueprints(page, size);
+		return ResponseEntity.ok(responses);
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/controller/DangerAreaController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/controller/DangerAreaController.java
@@ -4,7 +4,9 @@ import com.iroom.dashboard.dto.request.DangerAreaRequest;
 import com.iroom.dashboard.dto.response.DangerAreaResponse;
 import com.iroom.dashboard.dto.response.PagedResponse;
 import com.iroom.dashboard.service.DangerAreaService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,33 +16,36 @@ import java.util.Map;
 @RequestMapping("/danger-areas")
 @RequiredArgsConstructor
 public class DangerAreaController {
-    private final DangerAreaService dangerAreaService;
+	private final DangerAreaService dangerAreaService;
 
-    @PostMapping
-    public ResponseEntity<DangerAreaResponse> createDangerArea(@RequestBody DangerAreaRequest request) {
-        return ResponseEntity.ok(dangerAreaService.createDangerArea(request));
-    }
+	@PostMapping
+	public ResponseEntity<DangerAreaResponse> createDangerArea(@RequestBody DangerAreaRequest request) {
+		return ResponseEntity.ok(dangerAreaService.createDangerArea(request));
+	}
 
-    @PutMapping("/{id}")
-    public ResponseEntity<DangerAreaResponse> updateDangerArea(@PathVariable Long id, @RequestBody DangerAreaRequest request) {
-        return ResponseEntity.ok(dangerAreaService.updateDangerArea(id, request));
-    }
+	@PutMapping("/{id}")
+	public ResponseEntity<DangerAreaResponse> updateDangerArea(@PathVariable Long id,
+		@RequestBody DangerAreaRequest request) {
+		return ResponseEntity.ok(dangerAreaService.updateDangerArea(id, request));
+	}
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, Object>> deleteDangerArea(@PathVariable Long id) {
-        dangerAreaService.deleteDangerArea(id);
-        return ResponseEntity.ok(Map.of("message", "위험구역 삭제 완료", "deletedId", id));
-    }
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Map<String, Object>> deleteDangerArea(@PathVariable Long id) {
+		dangerAreaService.deleteDangerArea(id);
+		return ResponseEntity.ok(Map.of("message", "위험구역 삭제 완료", "deletedId", id));
+	}
 
-    @GetMapping
-    public ResponseEntity<PagedResponse<DangerAreaResponse>> getAllDangerAreas(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        if (size > 50) size = 50;
-        if (size < 0) size = 0;
+	@GetMapping
+	public ResponseEntity<PagedResponse<DangerAreaResponse>> getAllDangerAreas(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		if (size > 50)
+			size = 50;
+		if (size < 0)
+			size = 0;
 
-        PagedResponse<DangerAreaResponse> response = dangerAreaService.getAllDangerAreas(page, size);
-        return ResponseEntity.ok(response);
-    }
+		PagedResponse<DangerAreaResponse> response = dangerAreaService.getAllDangerAreas(page, size);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/request/BlueprintRequest.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/request/BlueprintRequest.java
@@ -1,9 +1,9 @@
 package com.iroom.dashboard.dto.request;
 
-public record BlueprintRequest (
-        String blueprintUrl,
-        Integer floor,
-        Double width,
-        Double height
-){
+public record BlueprintRequest(
+	String blueprintUrl,
+	Integer floor,
+	Double width,
+	Double height
+) {
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/request/DangerAreaRequest.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/request/DangerAreaRequest.java
@@ -1,9 +1,9 @@
 package com.iroom.dashboard.dto.request;
 
-public record DangerAreaRequest (
-        Long blueprintId,
-        String location,
-        Double width,
-        Double height
-){
+public record DangerAreaRequest(
+	Long blueprintId,
+	String location,
+	Double width,
+	Double height
+) {
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/response/BlueprintResponse.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/response/BlueprintResponse.java
@@ -2,21 +2,21 @@ package com.iroom.dashboard.dto.response;
 
 import com.iroom.dashboard.entity.Blueprint;
 
-public record BlueprintResponse (
-        Long id,
-        String blueprintUrl,
-        Integer floor,
-        Double width,
-        Double height
-){
-    // 엔티티 -> DTO로 변환하는 생성자
-    public BlueprintResponse(Blueprint blueprint){
-        this(
-                blueprint.getId(),
-                blueprint.getBlueprintUrl(),
-                blueprint.getFloor(),
-                blueprint.getWidth(),
-                blueprint.getHeight()
-        );
-    }
+public record BlueprintResponse(
+	Long id,
+	String blueprintUrl,
+	Integer floor,
+	Double width,
+	Double height
+) {
+	// 엔티티 -> DTO로 변환하는 생성자
+	public BlueprintResponse(Blueprint blueprint) {
+		this(
+			blueprint.getId(),
+			blueprint.getBlueprintUrl(),
+			blueprint.getFloor(),
+			blueprint.getWidth(),
+			blueprint.getHeight()
+		);
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/dto/response/DangerAreaResponse.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/dto/response/DangerAreaResponse.java
@@ -2,20 +2,20 @@ package com.iroom.dashboard.dto.response;
 
 import com.iroom.dashboard.entity.DangerArea;
 
-public record DangerAreaResponse (
-        Long id,
-        Long blueprintId,
-        String location,
-        Double width,
-        Double height
-){
-    public DangerAreaResponse(DangerArea entity) {
-        this(
-                entity.getId(),
-                entity.getBlueprintId(),
-                entity.getLocation(),
-                entity.getWidth(),
-                entity.getHeight()
-        );
-    }
+public record DangerAreaResponse(
+	Long id,
+	Long blueprintId,
+	String location,
+	Double width,
+	Double height
+) {
+	public DangerAreaResponse(DangerArea entity) {
+		this(
+			entity.getId(),
+			entity.getBlueprintId(),
+			entity.getLocation(),
+			entity.getWidth(),
+			entity.getHeight()
+		);
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/entity/Blueprint.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/entity/Blueprint.java
@@ -8,34 +8,34 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "Blueprint")
 public class Blueprint {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String blueprintUrl;
+	@Column(nullable = false)
+	private String blueprintUrl;
 
-    @Column(nullable = false)
-    private Integer floor;
+	@Column(nullable = false)
+	private Integer floor;
 
-    @Column(nullable = false)
-    private Double width;
+	@Column(nullable = false)
+	private Double width;
 
-    @Column(nullable = false)
-    private Double height;
+	@Column(nullable = false)
+	private Double height;
 
-    @Builder
-    public Blueprint (String blueprintUrl, Integer floor, Double width, Double height) {
-        this.blueprintUrl =  blueprintUrl;
-        this.floor = floor;
-        this.width = width;
-        this.height = height;
-    }
+	@Builder
+	public Blueprint(String blueprintUrl, Integer floor, Double width, Double height) {
+		this.blueprintUrl = blueprintUrl;
+		this.floor = floor;
+		this.width = width;
+		this.height = height;
+	}
 
-    public void update(String blueprintUrl, Integer floor, Double width, Double height) {
-        this.blueprintUrl = blueprintUrl;
-        this.floor = floor;
-        this.width = width;
-        this.height = height;
-    }
+	public void update(String blueprintUrl, Integer floor, Double width, Double height) {
+		this.blueprintUrl = blueprintUrl;
+		this.floor = floor;
+		this.width = width;
+		this.height = height;
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/entity/DangerArea.java
@@ -8,33 +8,33 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "DangerArea")
 public class DangerArea {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private Long blueprintId;
+	@Column(nullable = false)
+	private Long blueprintId;
 
-    @Column(nullable = false)
-    private String location;
+	@Column(nullable = false)
+	private String location;
 
-    @Column(nullable = false)
-    private Double width;
+	@Column(nullable = false)
+	private Double width;
 
-    @Column(nullable = false)
-    private Double height;
+	@Column(nullable = false)
+	private Double height;
 
-    @Builder
-    public DangerArea (Long blueprintId, String location, Double width, Double height){
-        this.blueprintId = blueprintId;
-        this.location = location;
-        this.width = width;
-        this.height = height;
-    }
+	@Builder
+	public DangerArea(Long blueprintId, String location, Double width, Double height) {
+		this.blueprintId = blueprintId;
+		this.location = location;
+		this.width = width;
+		this.height = height;
+	}
 
-    public void update(String location, Double width, Double height){
-        this.location = location;
-        this.width = width;
-        this.height = height;
-    }
+	public void update(String location, Double width, Double height) {
+		this.location = location;
+		this.width = width;
+		this.height = height;
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/repository/BlueprintRepository.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/repository/BlueprintRepository.java
@@ -1,6 +1,7 @@
 package com.iroom.dashboard.repository;
 
 import com.iroom.dashboard.entity.Blueprint;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/dashboard/src/main/java/com/iroom/dashboard/repository/DangerAreaRepository.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/repository/DangerAreaRepository.java
@@ -1,6 +1,7 @@
 package com.iroom.dashboard.repository;
 
 import com.iroom.dashboard.entity.DangerArea;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
@@ -5,7 +5,9 @@ import com.iroom.dashboard.dto.response.BlueprintResponse;
 import com.iroom.dashboard.dto.response.PagedResponse;
 import com.iroom.dashboard.entity.Blueprint;
 import com.iroom.dashboard.repository.BlueprintRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,39 +19,36 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BlueprintService {
 
-    private final BlueprintRepository blueprintRepository;
+	private final BlueprintRepository blueprintRepository;
 
-    public BlueprintResponse createBlueprint(BlueprintRequest request) {
-        Blueprint blueprint = Blueprint.builder()
-                .blueprintUrl(request.blueprintUrl())
-                .floor(request.floor())
-                .width(request.width())
-                .height(request.height())
-                .build();
-        return new BlueprintResponse(blueprintRepository.save(blueprint));
-    }
+	public BlueprintResponse createBlueprint(BlueprintRequest request) {
+		Blueprint blueprint = Blueprint.builder()
+			.blueprintUrl(request.blueprintUrl())
+			.floor(request.floor())
+			.width(request.width())
+			.height(request.height())
+			.build();
+		return new BlueprintResponse(blueprintRepository.save(blueprint));
+	}
 
+	public BlueprintResponse updateBlueprint(Long id, BlueprintRequest request) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("해당 도면이 존재하지 않습니다."));
+		blueprint.update(request.blueprintUrl(), request.floor(), request.width(), request.height());
+		return new BlueprintResponse(blueprint);
+	}
 
-    public BlueprintResponse updateBlueprint(Long id, BlueprintRequest request) {
-        Blueprint blueprint = blueprintRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 도면이 존재하지 않습니다."));
-        blueprint.update(request.blueprintUrl(), request.floor(), request.width(), request.height());
-        return new BlueprintResponse(blueprint);
-    }
+	public void deleteBlueprint(Long id) {
+		if (!blueprintRepository.existsById(id)) {
+			throw new IllegalArgumentException("해당 도면이 존재하지 않습니다.");
+		}
+		blueprintRepository.deleteById(id);
+	}
 
-
-    public void deleteBlueprint(Long id) {
-        if (!blueprintRepository.existsById(id)) {
-            throw new IllegalArgumentException("해당 도면이 존재하지 않습니다.");
-        }
-        blueprintRepository.deleteById(id);
-    }
-
-
-    public PagedResponse<BlueprintResponse> getAllBlueprints(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Blueprint> blueprints = blueprintRepository.findAll(pageable);
-        Page<BlueprintResponse> responsePage = blueprints.map(BlueprintResponse::new);
-        return PagedResponse.of(responsePage);
-    }
+	public PagedResponse<BlueprintResponse> getAllBlueprints(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Blueprint> blueprints = blueprintRepository.findAll(pageable);
+		Page<BlueprintResponse> responsePage = blueprints.map(BlueprintResponse::new);
+		return PagedResponse.of(responsePage);
+	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/DangerAreaService.java
@@ -5,7 +5,9 @@ import com.iroom.dashboard.dto.response.DangerAreaResponse;
 import com.iroom.dashboard.dto.response.PagedResponse;
 import com.iroom.dashboard.entity.DangerArea;
 import com.iroom.dashboard.repository.DangerAreaRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,37 +19,36 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DangerAreaService {
 
-    private final DangerAreaRepository dangerAreaRepository;
+	private final DangerAreaRepository dangerAreaRepository;
 
-    public DangerAreaResponse createDangerArea(DangerAreaRequest request) {
-        DangerArea dangerArea = DangerArea.builder()
-                .blueprintId(request.blueprintId())
-                .location(request.location())
-                .width(request.width())
-                .height(request.height())
-                .build();
-        return new DangerAreaResponse(dangerAreaRepository.save(dangerArea));
-    }
+	public DangerAreaResponse createDangerArea(DangerAreaRequest request) {
+		DangerArea dangerArea = DangerArea.builder()
+			.blueprintId(request.blueprintId())
+			.location(request.location())
+			.width(request.width())
+			.height(request.height())
+			.build();
+		return new DangerAreaResponse(dangerAreaRepository.save(dangerArea));
+	}
 
-    public DangerAreaResponse updateDangerArea(Long id, DangerAreaRequest request) {
-        DangerArea dangerArea = dangerAreaRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 위험구역이 존재하지 않습니다."));
-        dangerArea.update(request.location(), request.width(), request.height());
-        return new DangerAreaResponse(dangerArea);
-    }
+	public DangerAreaResponse updateDangerArea(Long id, DangerAreaRequest request) {
+		DangerArea dangerArea = dangerAreaRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("해당 위험구역이 존재하지 않습니다."));
+		dangerArea.update(request.location(), request.width(), request.height());
+		return new DangerAreaResponse(dangerArea);
+	}
 
-    public void deleteDangerArea(Long id) {
-        if (!dangerAreaRepository.existsById(id)) {
-            throw new IllegalArgumentException("해당 위험구역이 존재하지 않습니다.");
-        }
-        dangerAreaRepository.deleteById(id);
-    }
+	public void deleteDangerArea(Long id) {
+		if (!dangerAreaRepository.existsById(id)) {
+			throw new IllegalArgumentException("해당 위험구역이 존재하지 않습니다.");
+		}
+		dangerAreaRepository.deleteById(id);
+	}
 
-
-    public PagedResponse<DangerAreaResponse> getAllDangerAreas(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<DangerArea> dangerAreas = dangerAreaRepository.findAll(pageable);
-        Page<DangerAreaResponse> responsePage = dangerAreas.map(DangerAreaResponse::new);
-        return PagedResponse.of(responsePage);
-    }
+	public PagedResponse<DangerAreaResponse> getAllDangerAreas(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<DangerArea> dangerAreas = dangerAreaRepository.findAll(pageable);
+		Page<DangerAreaResponse> responsePage = dangerAreas.map(DangerAreaResponse::new);
+		return PagedResponse.of(responsePage);
+	}
 }

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -30,9 +30,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(BlueprintControllerTest.MockConfig.class)
 class BlueprintControllerTest {
 
-	@Autowired private MockMvc mockMvc;
-	@Autowired private ObjectMapper objectMapper;
-	@Autowired private BlueprintService blueprintService; // 직접 주입받음
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private BlueprintService blueprintService; // 직접 주입받음
 
 	@TestConfiguration
 	static class MockConfig {

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -48,11 +48,13 @@ class BlueprintControllerTest {
 	@Test
 	@DisplayName("도면 등록 성공")
 	void createBlueprintTest() throws Exception {
+		// given
 		BlueprintRequest request = new BlueprintRequest("url.png", 1, 100.0, 200.0);
 		BlueprintResponse response = new BlueprintResponse(1L, "url.png", 1, 100.0, 200.0);
 
 		Mockito.when(blueprintService.createBlueprint(any())).thenReturn(response);
 
+		// when & then
 		mockMvc.perform(post("/blueprints")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -64,11 +66,13 @@ class BlueprintControllerTest {
 	@Test
 	@DisplayName("도면 수정 성공")
 	void updateBlueprintTest() throws Exception {
+		// given
 		BlueprintRequest request = new BlueprintRequest("new_url.png", 2, 150.0, 250.0);
 		BlueprintResponse response = new BlueprintResponse(1L, "new_url.png", 2, 150.0, 250.0);
 
 		Mockito.when(blueprintService.updateBlueprint(eq(1L), any())).thenReturn(response);
 
+		// when & then
 		mockMvc.perform(put("/blueprints/1")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -80,8 +84,10 @@ class BlueprintControllerTest {
 	@Test
 	@DisplayName("도면 삭제 성공")
 	void deleteBlueprintTest() throws Exception {
+		// given
 		Mockito.doNothing().when(blueprintService).deleteBlueprint(1L);
 
+		// when & then
 		mockMvc.perform(delete("/blueprints/1"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("도면 삭제 완료"))
@@ -91,6 +97,7 @@ class BlueprintControllerTest {
 	@Test
 	@DisplayName("도면 전체 조회 성공")
 	void getAllBlueprintsTest() throws Exception {
+		// given
 		BlueprintResponse r1 = new BlueprintResponse(1L, "url1.png", 1, 100.0, 100.0);
 		BlueprintResponse r2 = new BlueprintResponse(2L, "url2.png", 2, 200.0, 200.0);
 
@@ -100,6 +107,7 @@ class BlueprintControllerTest {
 
 		Mockito.when(blueprintService.getAllBlueprints(0, 10)).thenReturn(pagedResponse);
 
+		// when & then
 		mockMvc.perform(get("/blueprints?page=0&size=10"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.content").isArray())

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -1,0 +1,106 @@
+package com.iroom.dashboard.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iroom.dashboard.dto.request.BlueprintRequest;
+import com.iroom.dashboard.dto.response.BlueprintResponse;
+import com.iroom.dashboard.dto.response.PagedResponse;
+import com.iroom.dashboard.service.BlueprintService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BlueprintController.class)
+@Import(BlueprintControllerTest.MockConfig.class)
+class BlueprintControllerTest {
+
+	@Autowired private MockMvc mockMvc;
+	@Autowired private ObjectMapper objectMapper;
+	@Autowired private BlueprintService blueprintService; // 직접 주입받음
+
+	@TestConfiguration
+	static class MockConfig {
+		@Bean
+		public BlueprintService blueprintService() {
+			return Mockito.mock(BlueprintService.class);
+		}
+	}
+
+	@Test
+	@DisplayName("도면 등록 성공")
+	void createBlueprintTest() throws Exception {
+		BlueprintRequest request = new BlueprintRequest("url.png", 1, 100.0, 200.0);
+		BlueprintResponse response = new BlueprintResponse(1L, "url.png", 1, 100.0, 200.0);
+
+		Mockito.when(blueprintService.createBlueprint(any())).thenReturn(response);
+
+		mockMvc.perform(post("/blueprints")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.blueprintUrl").value("url.png"))
+			.andExpect(jsonPath("$.floor").value(1));
+	}
+
+	@Test
+	@DisplayName("도면 수정 성공")
+	void updateBlueprintTest() throws Exception {
+		BlueprintRequest request = new BlueprintRequest("new_url.png", 2, 150.0, 250.0);
+		BlueprintResponse response = new BlueprintResponse(1L, "new_url.png", 2, 150.0, 250.0);
+
+		Mockito.when(blueprintService.updateBlueprint(eq(1L), any())).thenReturn(response);
+
+		mockMvc.perform(put("/blueprints/1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.blueprintUrl").value("new_url.png"))
+			.andExpect(jsonPath("$.floor").value(2));
+	}
+
+	@Test
+	@DisplayName("도면 삭제 성공")
+	void deleteBlueprintTest() throws Exception {
+		Mockito.doNothing().when(blueprintService).deleteBlueprint(1L);
+
+		mockMvc.perform(delete("/blueprints/1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("도면 삭제 완료"))
+			.andExpect(jsonPath("$.deletedId").value(1));
+	}
+
+	@Test
+	@DisplayName("도면 전체 조회 성공")
+	void getAllBlueprintsTest() throws Exception {
+		BlueprintResponse r1 = new BlueprintResponse(1L, "url1.png", 1, 100.0, 100.0);
+		BlueprintResponse r2 = new BlueprintResponse(2L, "url2.png", 2, 200.0, 200.0);
+
+		List<BlueprintResponse> content = List.of(r1, r2);
+		Page<BlueprintResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), content.size());
+		PagedResponse<BlueprintResponse> pagedResponse = PagedResponse.of(page);
+
+		Mockito.when(blueprintService.getAllBlueprints(0, 10)).thenReturn(pagedResponse);
+
+		mockMvc.perform(get("/blueprints?page=0&size=10"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content.length()").value(2))
+			.andExpect(jsonPath("$.content[0].floor").value(1));
+	}
+}

--- a/dashboard/src/test/java/com/iroom/dashboard/repository/BlueprintRepositoryTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/repository/BlueprintRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.iroom.dashboard.repository;
+
+import com.iroom.dashboard.entity.Blueprint;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class BlueprintRepositoryTest {
+
+	@Autowired
+	private BlueprintRepository blueprintRepository;
+
+	private Pageable pageable;
+
+	private Blueprint blueprint1;
+
+	@BeforeEach
+	void setUp() {
+		blueprintRepository.deleteAll();
+
+		blueprint1 = Blueprint.builder()
+			.blueprintUrl("https://example.com/blueprint1.png")
+			.floor(1)
+			.width(100.0)
+			.height(100.0)
+			.build();
+
+		Blueprint blueprint2 = Blueprint.builder()
+			.blueprintUrl("https://example.com/blueprint2.png")
+			.floor(2)
+			.width(200.0)
+			.height(200.0)
+			.build();
+
+		blueprintRepository.save(blueprint1);
+		blueprintRepository.save(blueprint2);
+
+		pageable = PageRequest.of(0, 10);
+	}
+
+	@Test
+	@DisplayName("도면 저장 및 ID로 조회 성공")
+	void saveAndFindById() {
+		// when
+		Optional<Blueprint> result = blueprintRepository.findById(blueprint1.getId());
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().getBlueprintUrl()).isEqualTo("https://example.com/blueprint1.png");
+	}
+
+	@Test
+	@DisplayName("도면 전체 조회 성공")
+	void findAllBlueprints() {
+		// when
+		Page<Blueprint> page = blueprintRepository.findAll(pageable);
+
+		// then
+		assertThat(page.getContent()).hasSize(2);
+		assertThat(page.getTotalElements()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("도면 삭제 성공")
+	void deleteBlueprint() {
+		// when
+		blueprintRepository.delete(blueprint1);
+
+		// then
+		Optional<Blueprint> result = blueprintRepository.findById(blueprint1.getId());
+		assertThat(result).isNotPresent();
+	}
+}

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -102,4 +102,31 @@ class BlueprintServiceTest {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("해당 도면이 존재하지 않습니다.");
 	}
+
+	@Test
+	@DisplayName("도면 삭제 성공")
+	void deleteBlueprintTest() {
+		// given
+		Long id = 1L;
+		given(blueprintRepository.existsById(id)).willReturn(true);
+
+		// when
+		blueprintService.deleteBlueprint(id);
+
+		// then
+		verify(blueprintRepository).deleteById(id);
+	}
+
+	@Test
+	@DisplayName("도면 삭제 실패 - 존재하지 않는 도면")
+	void deleteBlueprintFailNotFound() {
+		// given
+		Long id = 999L;
+		given(blueprintRepository.existsById(id)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> blueprintService.deleteBlueprint(id))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 도면이 존재하지 않습니다.");
+	}
 }

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -1,0 +1,72 @@
+package com.iroom.dashboard.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.iroom.dashboard.dto.request.BlueprintRequest;
+import com.iroom.dashboard.dto.response.BlueprintResponse;
+import com.iroom.dashboard.entity.Blueprint;
+import com.iroom.dashboard.repository.BlueprintRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BlueprintServiceTest {
+
+	@Mock
+	private BlueprintRepository blueprintRepository;
+
+	@InjectMocks
+	private BlueprintService blueprintService;
+
+	private Blueprint blueprint;
+	private Pageable pageable;
+	private Page<Blueprint> blueprintPage;
+
+	@BeforeEach
+	void setUp() {
+		blueprint = Blueprint.builder()
+			.blueprintUrl("url.png")
+			.floor(1)
+			.width(100.0)
+			.height(200.0)
+			.build();
+
+		Blueprint blueprint2 = Blueprint.builder()
+			.blueprintUrl("url2.png")
+			.floor(2)
+			.width(150.0)
+			.height(250.0)
+			.build();
+
+		pageable = PageRequest.of(0, 10);
+		blueprintPage = new PageImpl<>(List.of(blueprint, blueprint2), pageable, 2);
+	}
+
+	@Test
+	@DisplayName("도면 생성 성공")
+	void createBlueprintTest() {
+		// given
+		BlueprintRequest request = new BlueprintRequest("url.png", 1, 100.0, 200.0);
+		given(blueprintRepository.save(any(Blueprint.class))).willReturn(blueprint);
+
+		// when
+		BlueprintResponse response = blueprintService.createBlueprint(request);
+
+		// then
+		assertThat(response.blueprintUrl()).isEqualTo("url.png");
+		assertThat(response.floor()).isEqualTo(1);
+	}
+}

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -2,7 +2,6 @@ package com.iroom.dashboard.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.iroom.dashboard.dto.request.BlueprintRequest;
 import com.iroom.dashboard.dto.response.BlueprintResponse;
+import com.iroom.dashboard.dto.response.PagedResponse;
 import com.iroom.dashboard.entity.Blueprint;
 import com.iroom.dashboard.repository.BlueprintRepository;
 
@@ -128,5 +128,20 @@ class BlueprintServiceTest {
 		assertThatThrownBy(() -> blueprintService.deleteBlueprint(id))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("해당 도면이 존재하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("도면 전체 조회 성공")
+	void getAllBlueprintsTest() {
+		// given
+		given(blueprintRepository.findAll(pageable)).willReturn(blueprintPage);
+
+		// when
+		PagedResponse<BlueprintResponse> response = blueprintService.getAllBlueprints(0, 10);
+
+		// then
+		assertThat(response.content()).hasSize(2);
+		assertThat(response.totalElements()).isEqualTo(2);
+		assertThat(response.content().get(0).floor()).isEqualTo(1);
 	}
 }

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -2,8 +2,10 @@ package com.iroom.dashboard.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,5 +70,36 @@ class BlueprintServiceTest {
 		// then
 		assertThat(response.blueprintUrl()).isEqualTo("url.png");
 		assertThat(response.floor()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("도면 수정 성공")
+	void updateBlueprintTest() {
+		// given
+		Long id = 1L;
+		BlueprintRequest request = new BlueprintRequest("new_url.png", 1, 120.0, 220.0);
+		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprint));
+
+		// when
+		BlueprintResponse response = blueprintService.updateBlueprint(id, request);
+
+		// then
+		assertThat(response.blueprintUrl()).isEqualTo("new_url.png");
+		assertThat(response.width()).isEqualTo(120);
+		assertThat(response.height()).isEqualTo(220);
+	}
+
+	@Test
+	@DisplayName("도면 수정 실패 - 존재하지 않는 도면")
+	void updateBlueprintFailNotFound() {
+		// given
+		Long id = 99L;
+		BlueprintRequest request = new BlueprintRequest("x.png", 2, 50.0, 50.0);
+		given(blueprintRepository.findById(id)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> blueprintService.updateBlueprint(id, request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 도면이 존재하지 않습니다.");
 	}
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 리팩토링
---

## 변경 사항
- Blueprint 엔티티에 대한 CRUD 테스트 코드 추가

#### Controller
- Controller(WebMvcTest), Service(ExtendWith), Repository(DataJpaTest)로 분리하여 구현
- BlueprintService는 @TestConfiguration 통해 직접 Mockito mock 주입
- 기존 `@MockBean` 사용 대신, 향후 Deprecated 우려로 명시적 Bean 등록 방식 사용
- `@RestExceptionAdvice` 미적용 상태라 예외 테스트는 보류 (현재 컨트롤러에서 별도 예외 핸들링 없음)

#### Service(`@ExtendWith(MockitoExtension.class`)
- 서비스 로직에 대한 단위 테스트 구성
- Repository는 Mock 처리하여 비즈니스 로직에 집중
- 정상 케이스와 예외 케이스(존재하지 않는 ID) 모두 테스트
- 고민: 실패 상황 테스트 필요 여부 → IllegalArgumentException 등 명확한 예외가 있어 테스트 추가

#### Repository (`@DataJpaTest`)
- 실제 DB 기반 save/findAll/delete 동작 확인
- Entity 제약조건(nullable = false)에 대한 테스트는 향후 검토 예정
- **현재 테스트 시 testdb를 따로 두지 않아 바로 mysql에 값 적용됨(기본 내장 DB(H2) 사용이 아닌, 실제 운영 DB(MySQL)에 데이터가 저장되므로 주의 필요)**
---
## 테스트 결과
- Repository
<img width="417" height="165" alt="image" src="https://github.com/user-attachments/assets/382dc878-381b-4229-ba72-0b4b91bbf89d" />

- Service
<img width="445" height="270" alt="image" src="https://github.com/user-attachments/assets/d5f51c7b-36f5-43ee-8682-9a3dd1019ba8" />


- Controller
<img width="442" height="196" alt="image" src="https://github.com/user-attachments/assets/f197071b-41a6-420c-8d16-741434ec41af" />
