### PR TITLE
feat: 관리자 페이지별 UI 초기 구현

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,11 +3,15 @@ import {BrowserRouter as Router, Navigate, Route, Routes, useNavigate} from 'rea
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import AdminLogin from './pages/AdminLogin';
+import DashboardPage from './pages/DashboardPage';
+import MonitoringPage from './pages/MonitoringPage';
 import WorkerDetailPage from './pages/WorkerDetailPage';
 import WorkerManagementPage from './pages/WorkerManagementPage';
 import BlueprintPage from './pages/BlueprintPage';
 import SettingsPage from './pages/SettingsPage';
 import './App.css';
+import RiskZonePage from "./pages/RiskZonePage";
+import ReportPage from "./pages/ReportPage";
 
 // 공통 레이아웃 컴포넌트
 const CommonLayout = ({ children, currentPage }) => {
@@ -95,7 +99,7 @@ const App = () => {
                 {/* 대시보드 */}
                 <Route path="/admin/dashboard" element={
                     <CommonLayout currentPage="dashboard">
-                        <PlaceholderPage title="대시보드"/>
+                        <DashboardPage/>
                     </CommonLayout>
                 }/>
 
@@ -121,17 +125,17 @@ const App = () => {
                 {/* 나머지 페이지들 (임시) */}
                 <Route path="/admin/monitoring" element={
                     <CommonLayout currentPage="monitoring">
-                        <PlaceholderPage title="실시간 모니터링"/>
+                        <MonitoringPage/>
                     </CommonLayout>
                 }/>
                 <Route path="/admin/risk" element={
                     <CommonLayout currentPage="risk">
-                        <PlaceholderPage title="위험구역 관리"/>
+                        <RiskZonePage/>
                     </CommonLayout>
                 }/>
                 <Route path="/admin/report" element={
                     <CommonLayout currentPage="report">
-                        <PlaceholderPage title="리포트"/>
+                        <ReportPage/>
                     </CommonLayout>
                 }/>
                 <Route path="/admin/settings" element={

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -1,0 +1,273 @@
+import React, { useState, useEffect } from 'react';
+import styles from '../styles/Dashboard.module.css';
+// import { dashboardAPI } from '../api/api'; // API 연동 시 사용
+
+const DashboardPage = () => {
+    // 상태 표시 컴포넌트 (중복 코드 제거용)
+    const StatusDisplay = ({ icon, label, value, details, classPrefix }) => (
+        <>
+            <div className={styles[`${classPrefix}Content`]}>
+                <div className={styles[`${classPrefix}Icon`]}>{icon}</div>
+                <div className={styles[`${classPrefix}Text`]}>
+                    <p className={styles[`${classPrefix}Label`]}>{label}</p>
+                    <p className={styles[`${classPrefix}Value`]}>{value}</p>
+                </div>
+            </div>
+            <p className={styles[`${classPrefix}Details`]}>
+                {details}
+            </p>
+        </>
+    );
+
+    // 알림 아이콘 가져오기 함수
+    const getAlertIcon = (type) => type === 'danger' ? '🚨' : '⚠️';
+    // 종합 안전 점수
+    const [safetyScore] = useState(85);
+
+    // 실시간 위험 알림 데이터
+    const [alerts] = useState([
+        {
+            id: 1,
+            type: 'danger',
+            title: '위험구역 접근 경고',
+            description: '3층 공사 현장',
+            time: '5분 전'
+        },
+        {
+            id: 2,
+            type: 'warning',
+            title: '보호구 미착용',
+            description: '2층 작업 현장',
+            time: '10분 전'
+        },
+        {
+            id: 3,
+            type: 'warning',
+            title: '피로도 위험',
+            description: '건설 작업 영역',
+            time: '12분 전'
+        }
+    ]);
+
+    // 주요 안전 지표 데이터
+    const [indicators] = useState([
+        {
+            id: 1,
+            type: 'warning',
+            title: '보호구 미착용 작업자 수',
+            value: '2건',
+            icon: '⚠️'
+        },
+        {
+            id: 2,
+            type: 'warning',
+            title: '작업 안전 경고',
+            value: '1건',
+            icon: '⚠️'
+        },
+        {
+            id: 3,
+            type: 'danger',
+            title: '직원 이상 교원 수',
+            value: '3명',
+            icon: '😷'
+        }
+    ]);
+
+    // 현장 현황 데이터
+    const [fieldStatus] = useState({
+        currentWorkers: 24,
+        totalCapacity: 18,
+        dangerWorkers: 4,
+        normalWorkers: 2
+    });
+
+    // 유휴 인력 현황
+    const [idleStatus] = useState({
+        count: 3,
+        duration: '15분'
+    });
+
+    // 긴급 이상 탐지
+    const [emergencyStatus] = useState({
+        count: 1,
+        location: '박영희 - 심박수 이상'
+    });
+
+    // 도넛 차트 계산
+    const circumference = 2 * Math.PI * 90; // 반지름 90
+    const strokeDasharray = circumference;
+    const strokeDashoffset = circumference - (safetyScore / 100) * circumference;
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        // API 호출 로직
+        // fetchDashboardData();
+    }, []);
+
+    return (
+        <div className={styles.page}>
+            {/* 페이지 헤더 */}
+            <header className={styles.pageHeader}>
+                <h1 className={styles.pageTitle}>대시보드</h1>
+            </header>
+
+            {/* 상단 섹션 - 종합 안전 점수 + 변동 추이 */}
+            <section className={styles.topSection}>
+                {/* 종합 안전 점수 */}
+                <div className={styles.safetyScoreCard}>
+                    <h2 className={styles.safetyScoreTitle}>종합 안전 점수</h2>
+
+                    <div className={styles.chartContainer}>
+                        <svg className={styles.donutChart} viewBox="0 0 200 200">
+                            {/* 배경 원 */}
+                            <circle
+                                className={styles.chartBackground}
+                                cx="100"
+                                cy="100"
+                                r="90"
+                            />
+                            {/* 진행률 원 */}
+                            <circle
+                                className={styles.chartProgress}
+                                cx="100"
+                                cy="100"
+                                r="90"
+                                strokeDasharray={strokeDasharray}
+                                strokeDashoffset={strokeDashoffset}
+                            />
+                        </svg>
+
+                        <div className={styles.chartText}>
+                            <p className={styles.chartScore}>{safetyScore}점</p>
+                            <p className={styles.chartLabel}>안전 점수</p>
+                        </div>
+                    </div>
+
+                    <button className={styles.safetyStatusBtn}>
+                        양호
+                    </button>
+                </div>
+
+                {/* 안전 점수 변동 추이 */}
+                <div className={styles.trendCard}>
+                    <h2 className={styles.trendTitle}>안전 점수 변동 추이</h2>
+
+                    <div className={styles.trendCharts}>
+                        <div className={styles.trendChartItem}>
+                            <p className={styles.trendChartLabel}>일별 그래프</p>
+                            <div className={styles.trendChartPlaceholder}>
+                                📈 일별 차트
+                            </div>
+                        </div>
+
+                        <div className={styles.trendChartItem}>
+                            <p className={styles.trendChartLabel}>주별 그래프</p>
+                            <div className={styles.trendChartPlaceholder}>
+                                📊 주별 차트
+                            </div>
+                        </div>
+
+                        <div className={styles.trendChartItem}>
+                            <p className={styles.trendChartLabel}>월별 그래프</p>
+                            <div className={styles.trendChartPlaceholder}>
+                                📉 월별 차트
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* 하단 위젯 섹션 */}
+            <section className={styles.widgetsSection}>
+                {/* 실시간 위험 알림 */}
+                <div className={`${styles.widgetCard} ${styles.alertWidget}`}>
+                    <h3 className={styles.widgetTitle}>실시간 위험 알림</h3>
+
+                    <div className={styles.alertList}>
+                        {alerts.map(alert => (
+                            <div key={alert.id} className={`${styles.alertItem} ${styles[alert.type]}`}>
+                                <div className={`${styles.alertIcon} ${styles[alert.type]}`}>
+                                    {getAlertIcon(alert.type)}
+                                </div>
+                                <div className={styles.alertContent}>
+                                    <p className={styles.alertTitle}>{alert.title}</p>
+                                    <p className={styles.alertDesc}>{alert.description}</p>
+                                </div>
+                                <span className={styles.alertTime}>{alert.time}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 주요 안전 지표 */}
+                <div className={`${styles.widgetCard} ${styles.indicatorWidget}`}>
+                    <h3 className={styles.widgetTitle}>주요 안전 지표</h3>
+
+                    <div className={styles.indicatorList}>
+                        {indicators.map(indicator => (
+                            <div key={indicator.id} className={styles.indicatorItem}>
+                                <div className={`${styles.indicatorIcon} ${styles[indicator.type]}`}>
+                                    {indicator.icon}
+                                </div>
+                                <div className={styles.indicatorContent}>
+                                    <p className={styles.indicatorTitle}>{indicator.title}</p>
+                                    <p className={styles.indicatorValue}>{indicator.value}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 실시간 현장 현황 */}
+                <div className={`${styles.widgetCard} ${styles.statusWidget}`}>
+                    <h3 className={styles.widgetTitle}>실시간 현장 현황</h3>
+
+                    <div className={styles.statusSummary}>
+                        <div className={styles.statusIcon}>👨‍💼</div>
+                        <div className={styles.statusText}>
+                            <p className={styles.statusLabel}>현재 인원</p>
+                            <p className={styles.statusValue}>{fieldStatus.currentWorkers}명</p>
+                        </div>
+                    </div>
+
+                    <p className={styles.statusDetails}>
+                        건설: {fieldStatus.totalCapacity}명 | 안전: {fieldStatus.dangerWorkers}명 | 관리: {fieldStatus.normalWorkers}명
+                    </p>
+
+                    <button className={styles.statusBtn}>
+                        정상 운영
+                    </button>
+                </div>
+
+                {/* 유휴 인력 현황 */}
+                <div className={`${styles.widgetCard} ${styles.idleWidget}`}>
+                    <h3 className={styles.widgetTitle}>유휴 인력 현황</h3>
+
+                    <StatusDisplay
+                        icon="😴"
+                        label="유휴 상태"
+                        value={`${idleStatus.count}명`}
+                        details={`평균 유휴 시간: ${idleStatus.duration}`}
+                        classPrefix="idle"
+                    />
+                </div>
+
+                {/* 긴급 이상 탐지 */}
+                <div className={`${styles.widgetCard} ${styles.emergencyWidget}`}>
+                    <h3 className={styles.widgetTitle}>긴급 이상 탐지</h3>
+
+                    <StatusDisplay
+                        icon="🏥"
+                        label="이상 징후"
+                        value={`${emergencyStatus.count}명`}
+                        details={emergencyStatus.location}
+                        classPrefix="emergency"
+                    />
+                </div>
+            </section>
+        </div>
+    );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/MonitoringPage.js
+++ b/frontend/src/pages/MonitoringPage.js
@@ -104,7 +104,7 @@ const MonitoringPage = () => {
         <div className={styles.page}>
             {/* 페이지 헤더 */}
             <header className={styles.pageHeader}>
-                <h1 className={styles.pageTitle}>위험구역 관리</h1>
+                <h1 className={styles.pageTitle}>실시간 모니터링</h1>
                 <span className={styles.updateInfo}>마지막 업데이트: 2초전</span>
             </header>
 

--- a/frontend/src/pages/MonitoringPage.js
+++ b/frontend/src/pages/MonitoringPage.js
@@ -1,0 +1,272 @@
+import React, {useState, useEffect, useRef} from 'react';
+import styles from '../styles/Monitoring.module.css';
+// import { riskZoneAPI } from '../api/api'; // API 연동 시 사용
+
+const MonitoringPage = () => {
+    const mapRef = useRef(null);
+    const [selectedFilter, setSelectedFilter] = useState({
+        attribute: 'all',
+        riskLevel: 'all',
+        zone: 'all'
+    });
+
+    // 작업자 위치 데이터
+    const [workers] = useState([
+        {id: 1, x: 15, y: 25, status: 'danger', name: '김철수'},
+        {id: 2, x: 45, y: 15, status: 'warning', name: '이영희'},
+        {id: 3, x: 75, y: 30, status: 'safe', name: '박민수'},
+        {id: 4, x: 85, y: 45, status: 'safe', name: '정수진'},
+        {id: 5, x: 25, y: 60, status: 'warning', name: '한지민'},
+        {id: 6, x: 65, y: 70, status: 'safe', name: '조현우'},
+        {id: 7, x: 55, y: 50, status: 'danger', name: '윤서연'},
+        {id: 8, x: 35, y: 80, status: 'safe', name: '장동건'}
+    ]);
+
+    // 위험구역 데이터
+    const [dangerZones] = useState([
+        {id: 1, x: 15, y: 15, width: 25, height: 35, level: 'high', name: '고위험구역'},
+        {id: 2, x: 45, y: 35, width: 20, height: 20, level: 'medium', name: '중위험구역'}
+    ]);
+
+    // 현장 현황 데이터
+    const [fieldStatus] = useState({
+        totalWorkers: 24,
+        safeWorkers: 18,
+        warningWorkers: 4,
+        dangerWorkers: 2
+    });
+
+    // 실시간 경고 알림 데이터
+    const [alerts] = useState([
+        {
+            id: 1,
+            type: 'danger',
+            title: '위험구역 접근 경고',
+            description: '4층 공사 현장',
+            time: '5분 전'
+        },
+        {
+            id: 2,
+            type: 'warning',
+            title: '보호구 미착용',
+            description: '2층 작업 현장',
+            time: '10분 전'
+        },
+        {
+            id: 3,
+            type: 'warning',
+            title: '피로도 위험',
+            description: '건설 작업 영역',
+            time: '12분 전'
+        }
+    ]);
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        // API 호출 로직
+        // fetchRiskZoneData();
+    }, []);
+
+    // 필터 변경 핸들러
+    const handleFilterChange = (filterType, value) => {
+        setSelectedFilter(prev => ({
+            ...prev,
+            [filterType]: value
+        }));
+    };
+
+    // 작업자 클릭 핸들러
+    const handleWorkerClick = (worker) => {
+        alert(`작업자: ${worker.name}\n상태: ${getStatusText(worker.status)}`);
+    };
+
+    // 상태 텍스트 변환
+    const getStatusText = (status) => {
+        switch (status) {
+            case 'safe':
+                return '정상';
+            case 'warning':
+                return '주의';
+            case 'danger':
+                return '위험';
+            default:
+                return '알 수 없음';
+        }
+    };
+
+    // 필터된 작업자 목록
+    const filteredWorkers = workers.filter(worker => {
+        if (selectedFilter.attribute === 'all') return true;
+        return worker.status === selectedFilter.attribute;
+    });
+
+    return (
+        <div className={styles.page}>
+            {/* 페이지 헤더 */}
+            <header className={styles.pageHeader}>
+                <h1 className={styles.pageTitle}>위험구역 관리</h1>
+                <span className={styles.updateInfo}>마지막 업데이트: 2초전</span>
+            </header>
+
+            {/* 필터 섹션 */}
+            <section className={styles.filterSection}>
+                <select
+                    className={styles.filterDropdown}
+                    value={selectedFilter.attribute}
+                    onChange={(e) => handleFilterChange('attribute', e.target.value)}
+                >
+                    <option value="all">전체 속성</option>
+                    <option value="safe">정상</option>
+                    <option value="warning">주의</option>
+                    <option value="danger">위험</option>
+                </select>
+
+                <select
+                    className={styles.filterDropdown}
+                    value={selectedFilter.riskLevel}
+                    onChange={(e) => handleFilterChange('riskLevel', e.target.value)}
+                >
+                    <option value="all">위험도별</option>
+                    <option value="high">고위험</option>
+                    <option value="medium">중위험</option>
+                    <option value="low">저위험</option>
+                </select>
+
+                <select
+                    className={styles.filterDropdown}
+                    value={selectedFilter.zone}
+                    onChange={(e) => handleFilterChange('zone', e.target.value)}
+                >
+                    <option value="all">구역별</option>
+                    <option value="zone1">1구역</option>
+                    <option value="zone2">2구역</option>
+                    <option value="zone3">3구역</option>
+                </select>
+            </section>
+
+            {/* 메인 콘텐츠 */}
+            <div className={styles.contentSection}>
+                {/* 좌측: 도면 섹션 */}
+                <section className={styles.mapSection}>
+                    <h2 className={styles.mapTitle}>현장 도면 - 실시간 위치</h2>
+
+                    <div className={styles.mapContainer} ref={mapRef}>
+                        <div className={styles.mapCanvas}>
+                            {/* 위험구역 렌더링 */}
+                            {dangerZones.map(zone => (
+                                <div
+                                    key={zone.id}
+                                    className={`${styles.dangerZone} ${styles[zone.level]}`}
+                                    style={{
+                                        left: `${zone.x}%`,
+                                        top: `${zone.y}%`,
+                                        width: `${zone.width}%`,
+                                        height: `${zone.height}%`
+                                    }}
+                                    title={zone.name}
+                                />
+                            ))}
+
+                            {/* 작업자 위치 렌더링 */}
+                            {filteredWorkers.map(worker => (
+                                <div
+                                    key={worker.id}
+                                    className={`${styles.workerDot} ${styles[worker.status]}`}
+                                    style={{
+                                        left: `${worker.x}%`,
+                                        top: `${worker.y}%`
+                                    }}
+                                    onClick={() => handleWorkerClick(worker)}
+                                    title={`${worker.name} - ${getStatusText(worker.status)}`}
+                                />
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* 범례 */}
+                    <div className={styles.mapLegend}>
+                        <div className={styles.legendGroup}>
+                            <div className={styles.legendItem}>
+                                <div className={`${styles.legendColor} ${styles.safe}`}></div>
+                                <span>정상(18명)</span>
+                            </div>
+                            <div className={styles.legendItem}>
+                                <div className={`${styles.legendColor} ${styles.warning}`}></div>
+                                <span>주의(4명)</span>
+                            </div>
+                            <div className={styles.legendItem}>
+                                <div className={`${styles.legendColor} ${styles.danger}`}></div>
+                                <span>위험(2명)</span>
+                            </div>
+                        </div>
+
+                        <div className={styles.legendGroup}>
+                            <div className={styles.legendItem}>
+                                <div className={`${styles.legendZone} ${styles.high}`}></div>
+                                <span>중점관리 위험구역</span>
+                            </div>
+                            <div className={styles.legendItem}>
+                                <div className={`${styles.legendZone} ${styles.medium}`}></div>
+                                <span>고요 위험구역</span>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                {/* 우측: 정보 패널 */}
+                <aside className={styles.infoPanel}>
+                    {/* 실시간 현장 현황 */}
+                    <div className={styles.statusWidget}>
+                        <h3 className={styles.widgetTitle}>실시간 현장 현황</h3>
+
+                        <div className={styles.statusSummary}>
+                            <div className={styles.statusIcon}>👨‍💼</div>
+                            <div className={styles.statusText}>
+                                <p className={styles.statusLabel}>현재 인원</p>
+                                <p className={styles.statusValue}>{fieldStatus.totalWorkers}명</p>
+                            </div>
+                        </div>
+
+                        <p className={styles.statusDetails}>
+                            건설: {fieldStatus.safeWorkers}명 | 안전: {fieldStatus.warningWorkers}명 |
+                            관리: {fieldStatus.dangerWorkers}명
+                        </p>
+
+                        <button className={styles.statusButton}>
+                            정상 운영
+                        </button>
+                    </div>
+
+                    {/* 실시간 경고 알림 */}
+                    <div className={styles.alertWidget}>
+                        <h3 className={styles.widgetTitle}>실시간 경고 알림</h3>
+
+                        {alerts.length > 0 ? (
+                            <div className={styles.alertList}>
+                                {alerts.map(alert => (
+                                    <div key={alert.id} className={`${styles.alertItem} ${styles[alert.type]}`}>
+                                        <div className={`${styles.alertIcon} ${styles[alert.type]}`}>
+                                            {alert.type === 'danger' ? '🚨' : '⚠️'}
+                                        </div>
+                                        <div className={styles.alertContent}>
+                                            <p className={styles.alertTitle}>{alert.title}</p>
+                                            <p className={styles.alertDesc}>{alert.description}</p>
+                                        </div>
+                                        <span className={styles.alertTime}>{alert.time}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className={styles.emptyState}>
+                                <div className={styles.emptyIcon}>📭</div>
+                                <p>현재 알림이 없습니다</p>
+                            </div>
+                        )}
+                    </div>
+                </aside>
+            </div>
+        </div>
+    );
+};
+
+export default MonitoringPage;

--- a/frontend/src/pages/ReportPage.js
+++ b/frontend/src/pages/ReportPage.js
@@ -1,0 +1,437 @@
+import React, { useState, useEffect } from 'react';
+import styles from '../styles/Report.module.css';
+// import { reportAPI } from '../api/api'; // API 연동 시 사용
+
+const ReportPage = () => {
+    // 새 리포트 생성 폼 데이터
+    const [reportForm, setReportForm] = useState({
+        startDate: '',
+        endDate: '',
+        reportType: 'safety'
+    });
+
+    // 현재 페이지 상태
+    const [currentPage, setCurrentPage] = useState(0);
+    const [pageSize] = useState(5);
+    const [totalPages, setTotalPages] = useState(2);
+
+    // 리포트 목록 데이터
+    const [reports, setReports] = useState([
+        {
+            id: 1,
+            title: '6월 보호구 착용 분석',
+            type: '보호구 착용 분석',
+            period: '2025.06.01~06.30',
+            createdDate: '2025.07.01',
+            status: 'completed'
+        },
+        {
+            id: 2,
+            title: '6월 위험구역 분석',
+            type: '위험구역 분석',
+            period: '2025.06.01~06.30',
+            createdDate: '2025.07.01',
+            status: 'completed'
+        },
+        {
+            id: 3,
+            title: '6월 주간 안전 현황',
+            type: '종합 안전 현황',
+            period: '2025.06.01~06.08',
+            createdDate: '2025.06.09',
+            status: 'processing'
+        },
+        {
+            id: 4,
+            title: '6월 주간 안전 현황',
+            type: '종합 안전 현황',
+            period: '2025.06.01~06.08',
+            createdDate: '2025.06.09',
+            status: 'processing'
+        },
+        {
+            id: 5,
+            title: '6월 주간 안전 현황',
+            type: '종합 안전 현황',
+            period: '2025.06.01~06.08',
+            createdDate: '2025.06.09',
+            status: 'processing'
+        }
+    ]);
+
+    // AI 추천사항 데이터
+    const [recommendations] = useState([
+        {
+            id: 1,
+            icon: '⚠️',
+            title: '위험구역 접근 감소 방안',
+            description: '3구역 크레인 작업 시 주의 안전 클래스 설치로 경고합니다.'
+        },
+        {
+            id: 2,
+            icon: '🔷',
+            title: '보호구 착용 개선',
+            description: '오전 시간대 보호구 미착용 발견률이 높습니다. 안전 장갑 감지기 운용 개선.'
+        },
+        {
+            id: 3,
+            icon: '📊',
+            title: '근로자 건강 관리',
+            description: '고온 작업 시간대 휴식 시간을 10분 증가시킵니다. 건강 관리 보완.'
+        }
+    ]);
+
+    // 미리보기 통계 데이터
+    const [previewStats] = useState({
+        safetyScore: 87,
+        riskEvents: 12,
+        complianceRate: 98
+    });
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        fetchReports();
+    }, [currentPage]);
+
+    // 리포트 목록 조회
+    const fetchReports = async () => {
+        try {
+            // API 호출 로직
+            // const response = await reportAPI.getReports({
+            //     page: currentPage,
+            //     size: pageSize
+            // });
+            // setReports(response.data.content || []);
+            // setTotalPages(response.data.totalPages || 1);
+
+            console.log('리포트 목록 조회 - 페이지:', currentPage);
+        } catch (error) {
+            console.error('리포트 데이터 조회 실패:', error);
+        }
+    };
+
+    // 폼 입력 핸들러
+    const handleFormChange = (field, value) => {
+        setReportForm(prev => ({
+            ...prev,
+            [field]: value
+        }));
+    };
+
+    // 리포트 생성
+    const handleGenerateReport = async () => {
+        if (!reportForm.startDate || !reportForm.endDate) {
+            alert('보고서 기간을 선택해주세요.');
+            return;
+        }
+
+        try {
+            // API 호출 로직
+            // const reportData = {
+            //     startDate: reportForm.startDate,
+            //     endDate: reportForm.endDate,
+            //     type: reportForm.reportType
+            // };
+            // await reportAPI.generateReport(reportData);
+
+            alert('리포트 생성이 시작되었습니다.');
+
+            // 새로운 리포트를 목록에 추가 (임시)
+            const newReport = {
+                id: Date.now(),
+                title: `${getReportTypeLabel(reportForm.reportType)} 분석`,
+                type: getReportTypeLabel(reportForm.reportType),
+                period: `${reportForm.startDate}~${reportForm.endDate}`,
+                createdDate: new Date().toISOString().split('T')[0].replace(/-/g, '.'),
+                status: 'processing'
+            };
+
+            setReports(prev => [newReport, ...prev]);
+
+            // 폼 초기화
+            setReportForm({
+                startDate: '',
+                endDate: '',
+                reportType: 'safety'
+            });
+
+        } catch (error) {
+            console.error('리포트 생성 실패:', error);
+            alert('리포트 생성에 실패했습니다.');
+        }
+    };
+
+    // 리포트 타입 라벨 변환
+    const getReportTypeLabel = (type) => {
+        switch (type) {
+            case 'safety': return '종합 안전 현황';
+            case 'equipment': return '보호구 착용 분석';
+            case 'risk': return '위험구역 분석';
+            default: return '안전 분석';
+        }
+    };
+
+    // 상태 라벨 변환
+    const getStatusLabel = (status) => {
+        switch (status) {
+            case 'completed': return '완료';
+            case 'processing': return '진행중';
+            case 'pending': return '대기중';
+            default: return '알 수 없음';
+        }
+    };
+
+    // PDF 다운로드
+    const handlePdfDownload = () => {
+        alert('PDF 다운로드가 시작됩니다.');
+    };
+
+    // 엑셀 내보내기
+    const handleExcelExport = () => {
+        alert('엑셀 내보내기가 시작됩니다.');
+    };
+
+    // 리포트 다운로드
+    const handleDownload = (reportId) => {
+        console.log('리포트 다운로드:', reportId);
+        alert('리포트 다운로드가 시작됩니다.');
+    };
+
+    // 리포트 공유
+    const handleShare = (reportId) => {
+        console.log('리포트 공유:', reportId);
+        alert('공유 링크가 클립보드에 복사되었습니다.');
+    };
+
+    // 더 많은 추천사항 보기
+    const handleMoreRecommendations = () => {
+        alert('AI 추천사항 상세 페이지로 이동합니다.');
+    };
+
+    // 현재 페이지 데이터
+    const currentReports = reports.slice(
+        currentPage * pageSize,
+        (currentPage + 1) * pageSize
+    );
+
+    return (
+        <div className={styles.page}>
+            {/* 페이지 헤더 */}
+            <header className={styles.pageHeader}>
+                <h1 className={styles.pageTitle}>안전 보고서 생성 및 관리</h1>
+            </header>
+
+            {/* 상단 섹션 - 새 리포트 생성 + 미리보기 */}
+            <section className={styles.topSection}>
+                {/* 좌측: 새 리포트 생성 */}
+                <div className={styles.reportCreateSection}>
+                    <h2 className={styles.sectionTitle}>새 리포트 생성</h2>
+
+                    <div className={styles.formGroup}>
+                        <label className={styles.formLabel}>보고서 기간</label>
+                        <input
+                            type="date"
+                            className={styles.formInput}
+                            value={reportForm.startDate}
+                            onChange={(e) => handleFormChange('startDate', e.target.value)}
+                        />
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label className={styles.formLabel}>리포트 타입</label>
+                        <select
+                            className={styles.formSelect}
+                            value={reportForm.reportType}
+                            onChange={(e) => handleFormChange('reportType', e.target.value)}
+                        >
+                            <option value="safety">종합 안전 현황</option>
+                            <option value="equipment">보호구 착용 분석</option>
+                            <option value="risk">위험구역 분석</option>
+                        </select>
+                    </div>
+
+                    <button
+                        className={styles.generateButton}
+                        onClick={handleGenerateReport}
+                        disabled={!reportForm.startDate || !reportForm.endDate}
+                    >
+                        리포트 생성
+                    </button>
+                </div>
+
+                {/* 우측: 리포트 미리보기 */}
+                <div className={styles.previewSection}>
+                    <div className={styles.previewHeader}>
+                        <h2 className={styles.previewTitle}>리포트 미리보기</h2>
+                    </div>
+
+                    <div className={styles.chartsContainer}>
+                        <div className={styles.chartItem}>
+                            <p className={styles.chartTitle}>안전 점수 추이</p>
+                            <div className={styles.chartContainer}>
+                                <div className={styles.chartPlaceholder}>📊 안전 점수 차트</div>
+                                <div className={styles.chartStats}>
+                                    <p className={`${styles.chartValue} ${styles.safe}`}>{previewStats.safetyScore}점</p>
+                                    <p className={styles.chartLabel}>평균 안전 점수</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className={styles.chartItem}>
+                            <p className={styles.chartTitle}>위험 시간 발생 현황</p>
+                            <div className={styles.chartContainer}>
+                                <div className={styles.chartPlaceholder}>📈 위험 발생 차트</div>
+                                <div className={styles.chartStats}>
+                                    <p className={`${styles.chartValue} ${styles.danger}`}>{previewStats.riskEvents}건</p>
+                                    <p className={styles.chartLabel}>위험 시간</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className={styles.previewActions}>
+                        <button className={`${styles.previewButton} ${styles.pdfButton}`} onClick={handlePdfDownload}>
+                            PDF 다운로드
+                        </button>
+                        <button className={`${styles.previewButton} ${styles.exportButton}`} onClick={handleExcelExport}>
+                            엑셀 내보내기
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            {/* AI 개선사항 추천 섹션 */}
+            <section className={styles.aiRecommendationSection}>
+                <div className={styles.aiHeader}>
+                    <h2 className={styles.aiTitle}>AI 개선사항 추천</h2>
+                    <button className={styles.moreRecommendationsButton} onClick={handleMoreRecommendations}>
+                        더 많은 추천사항 보기
+                    </button>
+                </div>
+
+                <div className={styles.aiRecommendations}>
+                    {recommendations.map(recommendation => (
+                        <div key={recommendation.id} className={styles.recommendationCard}>
+                            <div className={styles.recommendationHeader}>
+                                <div className={styles.recommendationIcon}>
+                                    {recommendation.icon}
+                                </div>
+                                <h3 className={styles.recommendationTitle}>
+                                    {recommendation.title}
+                                </h3>
+                            </div>
+                            <p className={styles.recommendationDesc}>
+                                {recommendation.description}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            </section>
+
+            {/* 하단: 리포트 목록 테이블 */}
+            <section className={styles.tableSection}>
+                <h2 className={styles.tableTitle}>리포트 목록</h2>
+
+                <table className={styles.dataTable}>
+                    <thead>
+                    <tr>
+                        <th>리포트명</th>
+                        <th>타입</th>
+                        <th>기간</th>
+                        <th>생성일</th>
+                        <th>상태</th>
+                        <th>액션</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {currentReports.length > 0 ? (
+                        currentReports.map(report => (
+                            <tr key={report.id}>
+                                <td data-label="리포트명">{report.title}</td>
+                                <td data-label="타입">{report.type}</td>
+                                <td data-label="기간">{report.period}</td>
+                                <td data-label="생성일">{report.createdDate}</td>
+                                <td data-label="상태">
+                                        <span className={`${styles.statusBadge} ${styles[report.status]}`}>
+                                            {getStatusLabel(report.status)}
+                                        </span>
+                                </td>
+                                <td data-label="액션">
+                                    <div className={styles.actionButtons}>
+                                        <button
+                                            className={`${styles.actionButton} ${styles.downloadButton}`}
+                                            onClick={() => handleDownload(report.id)}
+                                            disabled={report.status !== 'completed'}
+                                        >
+                                            다운로드
+                                        </button>
+                                        <button
+                                            className={`${styles.actionButton} ${styles.shareButton}`}
+                                            onClick={() => handleShare(report.id)}
+                                            disabled={report.status !== 'completed'}
+                                        >
+                                            공유
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan="6" className={styles.emptyState}>
+                                생성된 리포트가 없습니다.
+                            </td>
+                        </tr>
+                    )}
+                    </tbody>
+                </table>
+
+                {/* 페이지네이션 */}
+                {totalPages > 1 && (
+                    <div className={styles.pagination}>
+                        <button
+                            className={styles.pageBtn}
+                            onClick={() => setCurrentPage(prev => Math.max(prev - 1, 0))}
+                            disabled={currentPage === 0}
+                        >
+                            ‹
+                        </button>
+
+                        {Array.from({ length: totalPages }, (_, index) => (
+                            <button
+                                key={index}
+                                className={`${styles.pageBtn} ${currentPage === index ? styles.active : ''}`}
+                                onClick={() => setCurrentPage(index)}
+                            >
+                                {index + 1}
+                            </button>
+                        ))}
+
+                        <button
+                            className={styles.pageBtn}
+                            onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages - 1))}
+                            disabled={currentPage >= totalPages - 1}
+                        >
+                            ›
+                        </button>
+
+                        <span style={{ margin: '0 16px', color: '#6B7280', fontSize: '14px' }}>...</span>
+
+                        <button className={styles.pageBtn}>
+                            40
+                        </button>
+
+                        <button
+                            className={styles.pageBtn}
+                            onClick={() => setCurrentPage(totalPages - 1)}
+                        >
+                            ››
+                        </button>
+                    </div>
+                )}
+            </section>
+        </div>
+    );
+};
+
+export default ReportPage;

--- a/frontend/src/pages/RiskZonePage.js
+++ b/frontend/src/pages/RiskZonePage.js
@@ -1,0 +1,458 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styles from '../styles/RiskZone.module.css';
+// import { riskZoneAPI } from '../api/api'; // API 연동 시 사용
+
+const RiskZonePage = () => {
+    const canvasRef = useRef(null);
+    const [selectedFloor, setSelectedFloor] = useState('1F');
+    const [isSelecting, setIsSelecting] = useState(false);
+    const [dragStart, setDragStart] = useState(null);
+    const [dragEnd, setDragEnd] = useState(null);
+    const [selectedZone, setSelectedZone] = useState(null);
+
+    // 선택된 위치 정보
+    const [locationInfo, setLocationInfo] = useState({
+        x: '',
+        y: '',
+        name: '',
+        width: '',
+        height: ''
+    });
+
+    // 현재 페이지 상태
+    const [currentPage, setCurrentPage] = useState(0);
+    const [pageSize] = useState(5);
+    const [totalPages, setTotalPages] = useState(1);
+
+    // 위험구역 목록 데이터
+    const [riskZones, setRiskZones] = useState([
+        {
+            id: 1,
+            floor: '1F',
+            name: '3구역 크레인 작업 구역',
+            location: 'X: 37.5721, Y: 126.9876',
+            width: '6.5 m',
+            height: '12 m'
+        },
+        {
+            id: 2,
+            floor: '2F',
+            name: '1구역 전기함',
+            location: 'X: 37.5719, Y: 126.9868',
+            width: '6.5 m',
+            height: '12 m'
+        },
+        {
+            id: 3,
+            floor: '3F',
+            name: '2구역 계단 작업 구역',
+            location: 'X: 37.5705, Y: 126.9880',
+            width: '3.8 m',
+            height: '2.2 m'
+        }
+    ]);
+
+    // 캔버스에 그려진 위험구역들
+    const [canvasZones, setCanvasZones] = useState([]);
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        fetchRiskZones();
+    }, [currentPage, selectedFloor]);
+
+    // 위험구역 데이터 조회
+    const fetchRiskZones = async () => {
+        try {
+            // API 호출 로직
+            // const response = await riskZoneAPI.getRiskZones({
+            //     page: currentPage,
+            //     size: pageSize,
+            //     floor: selectedFloor
+            // });
+            // setRiskZones(response.data.content || []);
+            // setTotalPages(response.data.totalPages || 1);
+
+            // 임시 데이터 필터링
+            const filteredZones = riskZones.filter(zone => zone.floor === selectedFloor);
+            setTotalPages(Math.ceil(filteredZones.length / pageSize));
+        } catch (error) {
+            console.error('위험구역 데이터 조회 실패:', error);
+        }
+    };
+
+    // 캔버스 마우스 이벤트 핸들러
+    const handleMouseDown = (e) => {
+        if (!isSelecting) return;
+
+        const rect = canvasRef.current.getBoundingClientRect();
+        const x = ((e.clientX - rect.left) / rect.width) * 100;
+        const y = ((e.clientY - rect.top) / rect.height) * 100;
+
+        setDragStart({ x, y });
+        setDragEnd({ x, y });
+    };
+
+    const handleMouseMove = (e) => {
+        if (!isSelecting || !dragStart) return;
+
+        const rect = canvasRef.current.getBoundingClientRect();
+        const x = ((e.clientX - rect.left) / rect.width) * 100;
+        const y = ((e.clientY - rect.top) / rect.height) * 100;
+
+        setDragEnd({ x, y });
+    };
+
+    const handleMouseUp = (e) => {
+        if (!isSelecting || !dragStart || !dragEnd) return;
+
+        const width = Math.abs(dragEnd.x - dragStart.x);
+        const height = Math.abs(dragEnd.y - dragStart.y);
+
+        if (width > 2 && height > 2) { // 최소 크기 체크
+            const newZone = {
+                id: Date.now(),
+                x: Math.min(dragStart.x, dragEnd.x),
+                y: Math.min(dragStart.y, dragEnd.y),
+                width: width,
+                height: height
+            };
+
+            setCanvasZones(prev => [...prev, newZone]);
+            setSelectedZone(newZone);
+
+            // 위치 정보 업데이트
+            setLocationInfo({
+                x: newZone.x.toFixed(2),
+                y: newZone.y.toFixed(2),
+                name: '',
+                width: (newZone.width * 0.1).toFixed(1), // 임시 스케일 변환
+                height: (newZone.height * 0.1).toFixed(1)
+            });
+        }
+
+        setDragStart(null);
+        setDragEnd(null);
+        setIsSelecting(false);
+    };
+
+    // Select Location 버튼 클릭
+    const handleSelectLocation = () => {
+        setIsSelecting(!isSelecting);
+        setDragStart(null);
+        setDragEnd(null);
+    };
+
+    // 위험구역 클릭
+    const handleZoneClick = (zone) => {
+        setSelectedZone(zone);
+        setLocationInfo({
+            x: zone.x.toFixed(2),
+            y: zone.y.toFixed(2),
+            name: zone.name || '',
+            width: (zone.width * 0.1).toFixed(1),
+            height: (zone.height * 0.1).toFixed(1)
+        });
+    };
+
+    // 위치 정보 저장
+    const handleSaveLocation = async () => {
+        if (!selectedZone || !locationInfo.name.trim()) {
+            alert('구역을 선택하고 이름을 입력해주세요.');
+            return;
+        }
+
+        try {
+            // API 호출 로직
+            // const zoneData = {
+            //     floor: selectedFloor,
+            //     name: locationInfo.name,
+            //     x: parseFloat(locationInfo.x),
+            //     y: parseFloat(locationInfo.y),
+            //     width: parseFloat(locationInfo.width),
+            //     height: parseFloat(locationInfo.height)
+            // };
+            // await riskZoneAPI.createRiskZone(zoneData);
+
+            alert('위험구역이 저장되었습니다.');
+
+            // 캔버스 위험구역에 이름 추가
+            setCanvasZones(prev =>
+                prev.map(zone =>
+                    zone.id === selectedZone.id
+                        ? { ...zone, name: locationInfo.name }
+                        : zone
+                )
+            );
+
+            // 목록 새로고침
+            await fetchRiskZones();
+
+            // 폼 초기화
+            setSelectedZone(null);
+            setLocationInfo({
+                x: '',
+                y: '',
+                name: '',
+                width: '',
+                height: ''
+            });
+
+        } catch (error) {
+            console.error('위험구역 저장 실패:', error);
+            alert('저장에 실패했습니다.');
+        }
+    };
+
+    // 위험구역 수정
+    const handleEdit = (zone) => {
+        console.log('위험구역 수정:', zone);
+        // 수정 모달 또는 폼 표시
+    };
+
+    // 위험구역 삭제
+    const handleDelete = async (zoneId) => {
+        if (!window.confirm('정말로 이 위험구역을 삭제하시겠습니까?')) {
+            return;
+        }
+
+        try {
+            // API 호출 로직
+            // await riskZoneAPI.deleteRiskZone(zoneId);
+
+            setRiskZones(prev => prev.filter(zone => zone.id !== zoneId));
+            alert('위험구역이 삭제되었습니다.');
+        } catch (error) {
+            console.error('위험구역 삭제 실패:', error);
+            alert('삭제에 실패했습니다.');
+        }
+    };
+
+    // 드래그 영역 계산
+    const getDragArea = () => {
+        if (!dragStart || !dragEnd) return null;
+
+        return {
+            left: `${Math.min(dragStart.x, dragEnd.x)}%`,
+            top: `${Math.min(dragStart.y, dragEnd.y)}%`,
+            width: `${Math.abs(dragEnd.x - dragStart.x)}%`,
+            height: `${Math.abs(dragEnd.y - dragStart.y)}%`
+        };
+    };
+
+    // 현재 페이지 데이터
+    const currentZones = riskZones
+        .filter(zone => zone.floor === selectedFloor)
+        .slice(currentPage * pageSize, (currentPage + 1) * pageSize);
+
+    return (
+        <div className={styles.page}>
+            {/* 페이지 헤더 */}
+            <header className={styles.pageHeader}>
+                <h1 className={styles.pageTitle}>위험구역 설정 및 관리</h1>
+            </header>
+
+            {/* 상단 섹션 */}
+            <section className={styles.topSection}>
+                {/* 좌측: 위험구역 설정 */}
+                <div className={styles.riskZoneSection}>
+                    <div className={styles.riskZoneHeader}>
+                        <h2 className={styles.sectionTitle}>위험 구역</h2>
+                        <select
+                            className={styles.floorSelect}
+                            value={selectedFloor}
+                            onChange={(e) => setSelectedFloor(e.target.value)}
+                        >
+                            <option value="1F">1F</option>
+                            <option value="2F">2F</option>
+                            <option value="3F">3F</option>
+                            <option value="4F">4F</option>
+                            <option value="5F">5F</option>
+                        </select>
+                    </div>
+
+                    <div
+                        className={`${styles.canvasContainer} ${isSelecting ? styles.drawing : ''}`}
+                        ref={canvasRef}
+                        onMouseDown={handleMouseDown}
+                        onMouseMove={handleMouseMove}
+                        onMouseUp={handleMouseUp}
+                    >
+                        <div className={styles.canvas}>
+                            {/* 기존 위험구역들 */}
+                            {canvasZones.map(zone => (
+                                <div
+                                    key={zone.id}
+                                    className={`${styles.riskZone} ${selectedZone?.id === zone.id ? styles.selected : ''}`}
+                                    style={{
+                                        left: `${zone.x}%`,
+                                        top: `${zone.y}%`,
+                                        width: `${zone.width}%`,
+                                        height: `${zone.height}%`
+                                    }}
+                                    onClick={() => handleZoneClick(zone)}
+                                    title={zone.name || '위험구역'}
+                                />
+                            ))}
+
+                            {/* 드래그 중인 영역 */}
+                            {dragStart && dragEnd && (
+                                <div
+                                    className={styles.dragArea}
+                                    style={getDragArea()}
+                                />
+                            )}
+                        </div>
+                    </div>
+                </div>
+
+                {/* 우측: Selected Location 정보 */}
+                <div className={styles.locationPanel}>
+                    <h3 className={styles.panelTitle}>Selected Location</h3>
+
+                    <div className={styles.coordinateInfo}>
+                        <p className={styles.coordinateText}>
+                            X: {locationInfo.x || '50.35'}, Y: {locationInfo.y || '64.63'}
+                        </p>
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label className={styles.formLabel}>Name</label>
+                        <input
+                            type="text"
+                            className={styles.formInput}
+                            value={locationInfo.name}
+                            onChange={(e) => setLocationInfo(prev => ({ ...prev, name: e.target.value }))}
+                            placeholder="위험구역 이름을 입력하세요"
+                        />
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label className={styles.formLabel}>Width</label>
+                        <input
+                            type="text"
+                            className={styles.formInput}
+                            value={locationInfo.width}
+                            onChange={(e) => setLocationInfo(prev => ({ ...prev, width: e.target.value }))}
+                            placeholder="너비 (m)"
+                            disabled={!selectedZone}
+                        />
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label className={styles.formLabel}>Height</label>
+                        <input
+                            type="text"
+                            className={styles.formInput}
+                            value={locationInfo.height}
+                            onChange={(e) => setLocationInfo(prev => ({ ...prev, height: e.target.value }))}
+                            placeholder="높이 (m)"
+                            disabled={!selectedZone}
+                        />
+                    </div>
+
+                    <div className={styles.buttonGroup}>
+                        <button
+                            className={`${styles.selectLocationBtn} ${isSelecting ? styles.active : ''}`}
+                            onClick={handleSelectLocation}
+                        >
+                            Select Location
+                        </button>
+                        <button
+                            className={styles.saveLocationBtn}
+                            onClick={handleSaveLocation}
+                            disabled={!selectedZone || !locationInfo.name.trim()}
+                        >
+                            위험구역 추가하룸
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            {/* 하단: 전체 위험구역 목록 */}
+            <section className={styles.tableSection}>
+                <h2 className={styles.tableTitle}>전체 위험구역 목록</h2>
+
+                <table className={styles.dataTable}>
+                    <thead>
+                    <tr>
+                        <th>Floor</th>
+                        <th>Name</th>
+                        <th>Location</th>
+                        <th>Width</th>
+                        <th>Height</th>
+                        <th>Button</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {currentZones.length > 0 ? (
+                        currentZones.map(zone => (
+                            <tr key={zone.id}>
+                                <td data-label="Floor">{zone.floor}</td>
+                                <td data-label="Name">{zone.name}</td>
+                                <td data-label="Location">{zone.location}</td>
+                                <td data-label="Width">{zone.width}</td>
+                                <td data-label="Height">{zone.height}</td>
+                                <td data-label="Button">
+                                    <div className={styles.actionButtons}>
+                                        <button
+                                            className={`${styles.actionButton} ${styles.editButton}`}
+                                            onClick={() => handleEdit(zone)}
+                                        >
+                                            수정
+                                        </button>
+                                        <button
+                                            className={`${styles.actionButton} ${styles.deleteButton}`}
+                                            onClick={() => handleDelete(zone.id)}
+                                        >
+                                            삭제
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan="6" className={styles.emptyState}>
+                                등록된 위험구역이 없습니다.
+                            </td>
+                        </tr>
+                    )}
+                    </tbody>
+                </table>
+
+                {/* 페이지네이션 */}
+                {totalPages > 1 && (
+                    <div className={styles.pagination}>
+                        <button
+                            className={styles.pageBtn}
+                            onClick={() => setCurrentPage(prev => Math.max(prev - 1, 0))}
+                            disabled={currentPage === 0}
+                        >
+                            ‹
+                        </button>
+
+                        {Array.from({ length: totalPages }, (_, index) => (
+                            <button
+                                key={index}
+                                className={`${styles.pageBtn} ${currentPage === index ? styles.active : ''}`}
+                                onClick={() => setCurrentPage(index)}
+                            >
+                                {index + 1}
+                            </button>
+                        ))}
+
+                        <button
+                            className={styles.pageBtn}
+                            onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages - 1))}
+                            disabled={currentPage >= totalPages - 1}
+                        >
+                            ›
+                        </button>
+                    </div>
+                )}
+            </section>
+        </div>
+    );
+};
+
+export default RiskZonePage;

--- a/frontend/src/pages/RiskZonePage.js
+++ b/frontend/src/pages/RiskZonePage.js
@@ -362,7 +362,7 @@ const RiskZonePage = () => {
                             onClick={handleSaveLocation}
                             disabled={!selectedZone || !locationInfo.name.trim()}
                         >
-                            위험구역 추가하룸
+                            위험구역 추가등록
                         </button>
                     </div>
                 </div>

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -1,0 +1,531 @@
+/* 전체 페이지 - 기존 스타일과 통일 */
+.page {
+    padding: 50px;
+    background-color: #FAFBFF;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+/* 페이지 헤더 - 기존과 동일 */
+.pageHeader {
+    margin-bottom: 8px;
+}
+
+.pageTitle {
+    font-size: 30px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+/* 상단 섹션 - 종합 안전 점수 + 변동 추이 */
+.topSection {
+    display: grid;
+    grid-template-columns: 400px 1fr;
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+/* 종합 안전 점수 카드 */
+.safetyScoreCard {
+    background: #fff;
+    border-radius: 12px;
+    padding: 32px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.safetyScoreTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 32px 0;
+}
+
+/* 도넛 차트 컨테이너 */
+.chartContainer {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    margin-bottom: 32px;
+}
+
+.donutChart {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.chartBackground {
+    fill: none;
+    stroke: #E5E7EB;
+    stroke-width: 20;
+}
+
+.chartProgress {
+    fill: none;
+    stroke: #10B981;
+    stroke-width: 20;
+    stroke-linecap: round;
+    transition: stroke-dasharray 1s ease-in-out;
+}
+
+.chartText {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
+
+.chartScore {
+    font-size: 36px;
+    font-weight: 700;
+    color: #10B981;
+    margin: 0;
+    line-height: 1;
+}
+
+.chartLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 4px 0 0 0;
+}
+
+/* 안전 상태 버튼 */
+.safetyStatusBtn {
+    background: #10B981;
+    color: white;
+    border: none;
+    border-radius: 24px;
+    padding: 12px 32px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.safetyStatusBtn:hover {
+    background: #059669;
+}
+
+/* 변동 추이 카드 */
+.trendCard {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.trendTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 24px 0;
+}
+
+.trendCharts {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+
+.trendChartItem {
+    text-align: center;
+}
+
+.trendChartLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 12px 0;
+}
+
+.trendChartPlaceholder {
+    width: 100%;
+    height: 120px;
+    background: #F3F4F6;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #9CA3AF;
+    font-size: 12px;
+    border: 2px dashed #D1D5DB;
+}
+
+/* 하단 위젯 그리드 */
+.widgetsSection {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 24px;
+}
+
+/* 위젯 카드 기본 스타일 */
+.widgetCard {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    min-height: 240px;
+}
+
+.widgetTitle {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 20px 0;
+}
+
+/* 실시간 위험 알림 위젯 */
+.alertWidget {
+    /* 기본 위젯 스타일 상속 */
+}
+
+.alertList {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
+}
+
+.alertItem {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 8px;
+    background: #FEF3C7;
+    border-left: 4px solid #F59E0B;
+}
+
+.alertItem.danger {
+    background: #FEE2E2;
+    border-left-color: #EF4444;
+}
+
+.alertIcon {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: white;
+    flex-shrink: 0;
+}
+
+.alertIcon.warning {
+    background: #F59E0B;
+}
+
+.alertIcon.danger {
+    background: #EF4444;
+}
+
+.alertContent {
+    flex: 1;
+    min-width: 0;
+}
+
+.alertTitle {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 2px 0;
+}
+
+.alertDesc {
+    font-size: 12px;
+    color: #6B7280;
+    margin: 0;
+}
+
+.alertTime {
+    font-size: 12px;
+    color: #9CA3AF;
+    flex-shrink: 0;
+}
+
+/* 주요 안전 지표 위젯 */
+.indicatorWidget {
+    /* 기본 위젯 스타일 상속 */
+}
+
+.indicatorList {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+}
+
+.indicatorItem {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.indicatorIcon {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.indicatorIcon.warning {
+    background: #FEF3C7;
+}
+
+.indicatorIcon.danger {
+    background: #FEE2E2;
+}
+
+.indicatorContent {
+    flex: 1;
+}
+
+.indicatorTitle {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 2px 0;
+}
+
+.indicatorValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+/* 현장 현황 위젯 */
+.statusWidget {
+    /* 기본 위젯 스타일 상속 */
+}
+
+.statusSummary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.statusIcon {
+    width: 32px;
+    height: 32px;
+    background: #FEF3C7;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+}
+
+.statusText {
+    flex: 1;
+}
+
+.statusLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 2px 0;
+}
+
+.statusValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+.statusDetails {
+    font-size: 14px;
+    color: #6B7280;
+    margin-bottom: 16px;
+}
+
+.statusBtn {
+    background: #10B981;
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 8px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    width: 100%;
+}
+
+/* 유휴 인력 현황 위젯 */
+.idleWidget {
+    /* 기본 위젯 스타일 상속 */
+}
+
+.idleContent {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.idleIcon {
+    width: 32px;
+    height: 32px;
+    background: #FEF3C7;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+}
+
+.idleText {
+    flex: 1;
+}
+
+.idleLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 2px 0;
+}
+
+.idleValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+.idleDetails {
+    font-size: 14px;
+    color: #6B7280;
+    margin-bottom: 16px;
+}
+
+/* 긴급 이상 탐지 위젯 */
+.emergencyWidget {
+    /* 기본 위젯 스타일 상속 */
+}
+
+.emergencyContent {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.emergencyIcon {
+    width: 32px;
+    height: 32px;
+    background: #FEE2E2;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+}
+
+.emergencyText {
+    flex: 1;
+}
+
+.emergencyLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 2px 0;
+}
+
+.emergencyValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+.emergencyDetails {
+    font-size: 14px;
+    color: #6B7280;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1440px) {
+    .widgetsSection {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 1024px) {
+    .page {
+        padding: 30px 20px;
+        gap: 24px;
+    }
+
+    .topSection {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .safetyScoreCard {
+        padding: 24px;
+    }
+
+    .chartContainer {
+        width: 160px;
+        height: 160px;
+    }
+
+    .widgetsSection {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .trendCharts {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+}
+
+@media (max-width: 768px) {
+    .pageTitle {
+        font-size: 24px;
+    }
+
+    .widgetsSection {
+        grid-template-columns: 1fr;
+    }
+
+    .safetyScoreCard {
+        padding: 20px;
+    }
+
+    .chartContainer {
+        width: 140px;
+        height: 140px;
+    }
+
+    .chartScore {
+        font-size: 28px;
+    }
+}
+
+@media (max-width: 480px) {
+    .page {
+        padding: 20px 10px;
+    }
+
+    .widgetCard {
+        padding: 16px;
+        min-height: 200px;
+    }
+}

--- a/frontend/src/styles/Monitoring.module.css
+++ b/frontend/src/styles/Monitoring.module.css
@@ -1,0 +1,496 @@
+/* 전체 페이지 - 기존 스타일과 통일 */
+.page {
+    padding: 50px;
+    background-color: #FAFBFF;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+/* 페이지 헤더 - 기존과 동일 */
+.pageHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.pageTitle {
+    font-size: 30px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+.updateInfo {
+    font-size: 14px;
+    color: #6B7280;
+}
+
+/* 필터 섹션 */
+.filterSection {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.filterDropdown {
+    min-width: 140px;
+    padding: 12px 16px;
+    border: 1px solid #D1D5DB;
+    border-radius: 8px;
+    background: white;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 16px;
+    padding-right: 40px;
+}
+
+.filterDropdown:focus {
+    outline: none;
+    border-color: #3B82F6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* 메인 콘텐츠 섹션 */
+.contentSection {
+    display: grid;
+    grid-template-columns: 1fr 400px;
+    gap: 32px;
+    flex: 1;
+}
+
+/* 좌측: 도면 섹션 */
+.mapSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    min-height: 600px;
+}
+
+.mapTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 24px 0;
+}
+
+/* 도면 컨테이너 */
+.mapContainer {
+    flex: 1;
+    position: relative;
+    background: #374151;
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 500px;
+}
+
+.mapCanvas {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    cursor: crosshair;
+}
+
+/* 작업자 위치 점들 */
+.workerDot {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    z-index: 10;
+}
+
+.workerDot:hover {
+    transform: scale(1.2);
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+}
+
+.workerDot.safe {
+    background-color: #10B981;
+}
+
+.workerDot.warning {
+    background-color: #F59E0B;
+}
+
+.workerDot.danger {
+    background-color: #EF4444;
+}
+
+/* 위험구역 표시 */
+.dangerZone {
+    position: absolute;
+    border: 3px solid #EF4444;
+    background-color: rgba(239, 68, 68, 0.1);
+    border-radius: 8px;
+}
+
+.dangerZone.high {
+    background-color: rgba(239, 68, 68, 0.2);
+    border-color: #DC2626;
+}
+
+.dangerZone.medium {
+    background-color: rgba(245, 158, 11, 0.15);
+    border-color: #F59E0B;
+}
+
+/* 범례 */
+.mapLegend {
+    display: flex;
+    gap: 24px;
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #E5E7EB;
+}
+
+.legendGroup {
+    display: flex;
+    gap: 16px;
+}
+
+.legendItem {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #6B7280;
+}
+
+.legendColor {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 0 0 1px #D1D5DB;
+}
+
+.legendColor.safe {
+    background-color: #10B981;
+}
+
+.legendColor.warning {
+    background-color: #F59E0B;
+}
+
+.legendColor.danger {
+    background-color: #EF4444;
+}
+
+.legendZone {
+    width: 16px;
+    height: 12px;
+    border-radius: 2px;
+    border: 2px solid;
+}
+
+.legendZone.high {
+    background-color: rgba(239, 68, 68, 0.2);
+    border-color: #EF4444;
+}
+
+.legendZone.medium {
+    background-color: rgba(245, 158, 11, 0.15);
+    border-color: #F59E0B;
+}
+
+/* 우측: 정보 패널 */
+.infoPanel {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+/* 현장 현황 위젯 */
+.statusWidget {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.widgetTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 20px 0;
+}
+
+.statusSummary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.statusIcon {
+    width: 32px;
+    height: 32px;
+    background: #FEF3C7;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.statusText {
+    flex: 1;
+}
+
+.statusLabel {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 4px 0;
+}
+
+.statusValue {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+.statusDetails {
+    font-size: 14px;
+    color: #6B7280;
+    margin-bottom: 20px;
+}
+
+.statusButton {
+    background: #10B981;
+    color: white;
+    border: none;
+    border-radius: 24px;
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    width: 100%;
+    transition: background-color 0.2s ease;
+}
+
+.statusButton:hover {
+    background: #059669;
+}
+
+/* 경고 알림 위젯 */
+.alertWidget {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    flex: 1;
+}
+
+.alertList {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.alertItem {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+    border-radius: 8px;
+    background: #F9FAFB;
+    border-left: 4px solid #D1D5DB;
+    transition: all 0.2s ease;
+}
+
+.alertItem:hover {
+    background: #F3F4F6;
+}
+
+.alertItem.danger {
+    background: #FEE2E2;
+    border-left-color: #EF4444;
+}
+
+.alertItem.warning {
+    background: #FEF3C7;
+    border-left-color: #F59E0B;
+}
+
+.alertIcon {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: white;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.alertIcon.danger {
+    background: #EF4444;
+}
+
+.alertIcon.warning {
+    background: #F59E0B;
+}
+
+.alertContent {
+    flex: 1;
+    min-width: 0;
+}
+
+.alertTitle {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 4px 0;
+}
+
+.alertDesc {
+    font-size: 13px;
+    color: #6B7280;
+    margin: 0 0 4px 0;
+}
+
+.alertTime {
+    font-size: 12px;
+    color: #9CA3AF;
+    text-align: right;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+/* 빈 상태 */
+.emptyState {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+    color: #9CA3AF;
+    font-style: italic;
+    text-align: center;
+}
+
+.emptyIcon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.5;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1200px) {
+    .contentSection {
+        grid-template-columns: 1fr 350px;
+        gap: 24px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .page {
+        padding: 30px 20px;
+        gap: 24px;
+    }
+
+    .contentSection {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .infoPanel {
+        grid-template-columns: repeat(2, 1fr);
+        display: grid;
+    }
+
+    .filterSection {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .filterDropdown {
+        min-width: 120px;
+    }
+}
+
+@media (max-width: 768px) {
+    .pageTitle {
+        font-size: 24px;
+    }
+
+    .pageHeader {
+        flex-direction: column;
+        gap: 8px;
+        align-items: flex-start;
+    }
+
+    .mapSection {
+        padding: 16px;
+        min-height: 400px;
+    }
+
+    .mapContainer {
+        min-height: 300px;
+    }
+
+    .statusWidget,
+    .alertWidget {
+        padding: 16px;
+    }
+
+    .infoPanel {
+        grid-template-columns: 1fr;
+    }
+
+    .mapLegend {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .legendGroup {
+        gap: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .page {
+        padding: 20px 10px;
+    }
+
+    .filterSection {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .filterDropdown {
+        min-width: auto;
+    }
+
+    .alertItem {
+        padding: 12px;
+    }
+
+    .statusSummary {
+        flex-direction: column;
+        text-align: center;
+        gap: 8px;
+    }
+}

--- a/frontend/src/styles/Report.module.css
+++ b/frontend/src/styles/Report.module.css
@@ -1,0 +1,632 @@
+.page {
+    padding: 50px;
+    background-color: #FAFBFF;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+.pageHeader {
+    margin-bottom: 8px;
+}
+
+.pageTitle {
+    font-size: 30px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+/* 상단 섹션 - 새 리포트 생성 + 미리보기 */
+.topSection {
+    display: grid;
+    grid-template-columns: 400px 1fr;
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+/* 좌측: 새 리포트 생성 섹션 */
+.reportCreateSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.sectionTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.formGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.formLabel {
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+}
+
+.formInput,
+.formSelect {
+    padding: 12px 16px;
+    border: 1px solid #D1D5DB;
+    border-radius: 8px;
+    font-size: 14px;
+    transition: border-color 0.2s ease;
+    background: white;
+}
+
+.formInput:focus,
+.formSelect:focus {
+    outline: none;
+    border-color: #3B82F6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.formSelect {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 16px;
+    padding-right: 40px;
+}
+
+.generateButton {
+    background: #1F2937;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 14px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    margin-top: 8px;
+}
+
+.generateButton:hover {
+    background: #374151;
+}
+
+.generateButton:disabled {
+    background: #D1D5DB;
+    cursor: not-allowed;
+}
+
+/* 우측: 리포트 미리보기 섹션 */
+.previewSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.previewHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.previewTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.chartsContainer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+}
+
+.chartItem {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.chartTitle {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0;
+    text-align: center;
+}
+
+.chartContainer {
+    background: #F9FAFB;
+    border-radius: 8px;
+    padding: 20px;
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #E5E7EB;
+}
+
+.chartPlaceholder {
+    width: 100%;
+    height: 120px;
+    background: #E5E7EB;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #9CA3AF;
+    font-size: 12px;
+    margin-bottom: 12px;
+}
+
+.chartStats {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.chartValue {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.chartValue.safe {
+    color: #10B981;
+}
+
+.chartValue.danger {
+    color: #EF4444;
+}
+
+.chartValue.info {
+    color: #3B82F6;
+}
+
+.chartLabel {
+    font-size: 12px;
+    color: #6B7280;
+    margin: 0;
+}
+
+.previewActions {
+    display: flex;
+    gap: 12px;
+}
+
+.previewButton {
+    flex: 1;
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.pdfButton {
+    background: #1F2937;
+    color: white;
+    border: none;
+}
+
+.pdfButton:hover {
+    background: #374151;
+}
+
+.exportButton {
+    background: white;
+    color: #1F2937;
+    border: 1px solid #D1D5DB;
+}
+
+.exportButton:hover {
+    background: #F9FAFB;
+}
+
+/* AI 개선사항 추천 섹션 */
+.aiRecommendationSection {
+    background: linear-gradient(135deg, #3B82F6 0%, #1D4ED8 100%);
+    border-radius: 12px;
+    padding: 32px;
+    box-shadow: 0 4px 6px rgba(59, 130, 246, 0.1);
+    margin-bottom: 32px;
+}
+
+.aiHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.aiTitle {
+    font-size: 20px;
+    font-weight: 700;
+    color: white;
+    margin: 0;
+}
+
+.aiRecommendations {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+}
+
+.recommendationCard {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 12px;
+    padding: 20px;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: all 0.2s ease;
+}
+
+.recommendationCard:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+}
+
+.recommendationHeader {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.recommendationIcon {
+    width: 32px;
+    height: 32px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.recommendationTitle {
+    font-size: 16px;
+    font-weight: 600;
+    color: white;
+    margin: 0;
+}
+
+.recommendationDesc {
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.5;
+    margin: 0;
+}
+
+.moreRecommendationsButton {
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    backdrop-filter: blur(10px);
+}
+
+.moreRecommendationsButton:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+/* 하단: 리포트 목록 테이블 */
+.tableSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.tableTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 20px 0;
+}
+
+/* 테이블 스타일 - 기존과 통일 */
+.dataTable {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #E5E7EB;
+}
+
+.dataTable thead {
+    background: #F9FAFB;
+}
+
+.dataTable th {
+    padding: 12px 16px;
+    text-align: left;
+    font-size: 14px;
+    font-weight: 600;
+    color: #374151;
+    border-bottom: 1px solid #E5E7EB;
+}
+
+.dataTable td {
+    padding: 16px;
+    font-size: 14px;
+    color: #1F2937;
+    border-bottom: 1px solid #F3F4F6;
+    vertical-align: middle;
+}
+
+.dataTable tbody tr:hover {
+    background: #F9FAFB;
+}
+
+.dataTable tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* 상태 뱃지 */
+.statusBadge {
+    padding: 6px 12px;
+    border-radius: 16px;
+    font-size: 12px;
+    font-weight: 600;
+    display: inline-block;
+    min-width: 60px;
+    text-align: center;
+}
+
+.statusBadge.completed {
+    background: #D1FAE5;
+    color: #065F46;
+}
+
+.statusBadge.processing {
+    background: #FEF3C7;
+    color: #92400E;
+}
+
+.statusBadge.pending {
+    background: #E0E7FF;
+    color: #3730A3;
+}
+
+/* 액션 버튼들 */
+.actionButtons {
+    display: flex;
+    gap: 8px;
+}
+
+.actionButton {
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s ease;
+}
+
+.downloadButton {
+    background: #1F2937;
+    color: white;
+}
+
+.downloadButton:hover {
+    background: #374151;
+}
+
+.shareButton {
+    background: #F59E0B;
+    color: white;
+}
+
+.shareButton:hover {
+    background: #D97706;
+}
+
+/* 페이지네이션 - 기존과 동일 */
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px 0 0 0;
+    margin-top: 20px;
+    border-top: 1px solid #E5E7EB;
+}
+
+.pageBtn {
+    padding: 8px 12px;
+    border: 1px solid #D1D5DB;
+    background: white;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    transition: all 0.2s ease;
+}
+
+.pageBtn:hover:not(:disabled) {
+    background-color: #F3F4F6;
+}
+
+.pageBtn:disabled {
+    color: #9CA3AF;
+    cursor: not-allowed;
+    background-color: #F9FAFB;
+}
+
+.pageBtn.active {
+    background-color: #3B82F6;
+    color: white;
+    border-color: #3B82F6;
+}
+
+/* 빈 상태 */
+.emptyState {
+    padding: 60px 20px;
+    text-align: center;
+    color: #9CA3AF;
+    font-style: italic;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1200px) {
+    .topSection {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .chartsContainer {
+        grid-template-columns: 1fr;
+    }
+
+    .aiRecommendations {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .page {
+        padding: 30px 20px;
+        gap: 24px;
+    }
+
+    .aiRecommendationSection {
+        padding: 24px;
+    }
+
+    .aiRecommendations {
+        grid-template-columns: 1fr;
+    }
+
+    .chartsContainer {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .pageTitle {
+        font-size: 24px;
+    }
+
+    .reportCreateSection,
+    .previewSection,
+    .tableSection {
+        padding: 16px;
+    }
+
+    .aiRecommendationSection {
+        padding: 20px;
+    }
+
+    .aiHeader {
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
+    }
+
+    .previewActions {
+        flex-direction: column;
+    }
+
+    /* 전체 테이블 스타일 */
+    .dataTable {
+        font-size: 0.75rem;
+    }
+
+    /* 공통 셀 패딩 */
+    .dataTable th,
+    .dataTable td {
+        padding: 12px 8px;
+    }
+
+    /* 반응형 모바일 카드 형태로 전환 */
+    @media (max-width: 768px) {
+        .dataTable,
+        .dataTable thead,
+        .dataTable tbody,
+        .dataTable th,
+        .dataTable td,
+        .dataTable tr {
+            display: block;
+        }
+
+        /* 테이블 헤더 숨김 */
+        .dataTable thead tr {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+        }
+
+        /* 각 행을 카드처럼 표시 */
+        .dataTable tr {
+            border: 1px solid #E5E7EB;
+            border-radius: 8px;
+            margin-bottom: 12px;
+            padding: 16px;
+            background: white;
+        }
+
+        /* 셀 스타일 - 앞에 레이블 붙이기 */
+        .dataTable td {
+            border: none;
+            padding: 8px 0 8px 30%;
+            position: relative;
+        }
+
+        .dataTable td:before {
+            content: attr(data-label) ": ";
+            position: absolute;
+            left: 6px;
+            width: 25%;
+            padding-right: 10px;
+            white-space: nowrap;
+            font-weight: 600;
+            color: #6B7280;
+        }
+    }
+}
+
+@media (max-width: 480px) {
+    .page {
+        padding: 20px 10px;
+    }
+
+    .aiTitle {
+        font-size: 18px;
+    }
+
+    .actionButtons {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .actionButton {
+        width: 100%;
+        text-align: center;
+    }
+}

--- a/frontend/src/styles/RiskZone.module.css
+++ b/frontend/src/styles/RiskZone.module.css
@@ -1,0 +1,504 @@
+/* 전체 페이지 - 기존 스타일과 통일 */
+.page {
+    padding: 50px;
+    background-color: #FAFBFF;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    width: 100%;
+}
+
+/* 페이지 헤더 - 기존과 동일 */
+.pageHeader {
+    margin-bottom: 8px;
+}
+
+.pageTitle {
+    font-size: 30px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0;
+}
+
+/* 상단 섹션 - 위험구역 설정 + 선택된 위치 정보 */
+.topSection {
+    display: grid;
+    grid-template-columns: 1fr 350px;
+    gap: 32px;
+    margin-bottom: 32px;
+}
+
+/* 좌측: 위험구역 설정 섹션 */
+.riskZoneSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+.riskZoneHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.sectionTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.floorSelect {
+    min-width: 120px;
+    padding: 8px 12px;
+    border: 1px solid #D1D5DB;
+    border-radius: 6px;
+    background: white;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    background-size: 16px;
+    padding-right: 32px;
+}
+
+.floorSelect:focus {
+    outline: none;
+    border-color: #3B82F6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* 캔버스 컨테이너 */
+.canvasContainer {
+    flex: 1;
+    position: relative;
+    background: #F3F4F6;
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 400px;
+    border: 2px dashed #D1D5DB;
+    cursor: crosshair;
+}
+
+.canvasContainer.drawing {
+    cursor: crosshair;
+}
+
+.canvas {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+/* 위험구역 표시 */
+.riskZone {
+    position: absolute;
+    border: 2px solid #EF4444;
+    background-color: rgba(239, 68, 68, 0.1);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.riskZone:hover {
+    background-color: rgba(239, 68, 68, 0.2);
+    border-color: #DC2626;
+}
+
+.riskZone.selected {
+    border-color: #3B82F6;
+    background-color: rgba(59, 130, 246, 0.1);
+}
+
+.riskZone.selected:hover {
+    background-color: rgba(59, 130, 246, 0.2);
+}
+
+/* 임시 드래그 영역 */
+.dragArea {
+    position: absolute;
+    border: 2px dashed #3B82F6;
+    background-color: rgba(59, 130, 246, 0.1);
+    pointer-events: none;
+}
+
+/* 우측: 선택된 위치 정보 패널 */
+.locationPanel {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.panelTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.coordinateInfo {
+    padding: 12px;
+    background: #F9FAFB;
+    border-radius: 6px;
+    border: 1px solid #E5E7EB;
+}
+
+.coordinateText {
+    font-size: 14px;
+    color: #374151;
+    margin: 0;
+    font-family: 'Courier New', monospace;
+}
+
+.formGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.formLabel {
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+}
+
+.formInput {
+    padding: 10px 12px;
+    border: 1px solid #D1D5DB;
+    border-radius: 6px;
+    font-size: 14px;
+    transition: border-color 0.2s ease;
+}
+
+.formInput:focus {
+    outline: none;
+    border-color: #3B82F6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.formInput:disabled {
+    background-color: #F9FAFB;
+    color: #6B7280;
+    cursor: not-allowed;
+}
+
+.buttonGroup {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.selectLocationBtn {
+    flex: 1;
+    padding: 10px 16px;
+    border: 1px solid #3B82F6;
+    background: white;
+    color: #3B82F6;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.selectLocationBtn:hover {
+    background: #3B82F6;
+    color: white;
+}
+
+.selectLocationBtn.active {
+    background: #3B82F6;
+    color: white;
+}
+
+.saveLocationBtn {
+    flex: 2;
+    padding: 10px 16px;
+    border: none;
+    background: #3B82F6;
+    color: white;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.saveLocationBtn:hover {
+    background: #2563EB;
+}
+
+.saveLocationBtn:disabled {
+    background: #D1D5DB;
+    cursor: not-allowed;
+}
+
+/* 하단: 위험구역 목록 테이블 */
+.tableSection {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.tableTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 20px 0;
+}
+
+/* 테이블 스타일 - 기존과 통일 */
+.dataTable {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #E5E7EB;
+}
+
+.dataTable thead {
+    background: #F9FAFB;
+}
+
+.dataTable th {
+    padding: 12px 16px;
+    text-align: left;
+    font-size: 14px;
+    font-weight: 600;
+    color: #374151;
+    border-bottom: 1px solid #E5E7EB;
+}
+
+.dataTable td {
+    padding: 16px;
+    font-size: 14px;
+    color: #1F2937;
+    border-bottom: 1px solid #F3F4F6;
+}
+
+.dataTable tbody tr:hover {
+    background: #F9FAFB;
+}
+
+.dataTable tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* 액션 버튼들 */
+.actionButtons {
+    display: flex;
+    gap: 8px;
+}
+
+.actionButton {
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s ease;
+}
+
+.editButton {
+    background: #F59E0B;
+    color: white;
+}
+
+.editButton:hover {
+    background: #D97706;
+}
+
+.deleteButton {
+    background: #EF4444;
+    color: white;
+}
+
+.deleteButton:hover {
+    background: #DC2626;
+}
+
+/* 페이지네이션 - 기존과 동일 */
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px 0 0 0;
+    margin-top: 20px;
+    border-top: 1px solid #E5E7EB;
+}
+
+.pageBtn {
+    padding: 8px 12px;
+    border: 1px solid #D1D5DB;
+    background: white;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    transition: all 0.2s ease;
+}
+
+.pageBtn:hover:not(:disabled) {
+    background-color: #F3F4F6;
+}
+
+.pageBtn:disabled {
+    color: #9CA3AF;
+    cursor: not-allowed;
+    background-color: #F9FAFB;
+}
+
+.pageBtn.active {
+    background-color: #3B82F6;
+    color: white;
+    border-color: #3B82F6;
+}
+
+/* 빈 상태 */
+.emptyState {
+    padding: 60px 20px;
+    text-align: center;
+    color: #9CA3AF;
+    font-style: italic;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1200px) {
+    .topSection {
+        grid-template-columns: 1fr 320px;
+        gap: 24px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .page {
+        padding: 30px 20px;
+        gap: 24px;
+    }
+
+    .topSection {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .locationPanel {
+        order: -1;
+    }
+
+    .riskZoneSection {
+        min-height: 350px;
+    }
+
+    .canvasContainer {
+        min-height: 300px;
+    }
+}
+
+@media (max-width: 768px) {
+    .pageTitle {
+        font-size: 24px;
+    }
+
+    .riskZoneSection,
+    .locationPanel,
+    .tableSection {
+        padding: 16px;
+    }
+
+    .riskZoneHeader {
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
+    }
+
+    .buttonGroup {
+        flex-direction: column;
+    }
+
+    .dataTable {
+        font-size: 12px;
+    }
+
+    .dataTable th,
+    .dataTable td {
+        padding: 12px 8px;
+    }
+
+    /* 모바일에서 테이블을 카드 형태로 변경 */
+    .dataTable,
+    .dataTable thead,
+    .dataTable tbody,
+    .dataTable th,
+    .dataTable td,
+    .dataTable tr {
+        display: block;
+    }
+
+    .dataTable thead tr {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+
+    .dataTable tr {
+        border: 1px solid #E5E7EB;
+        border-radius: 8px;
+        margin-bottom: 12px;
+        padding: 16px;
+        background: white;
+    }
+
+    .dataTable td {
+        border: none;
+        padding: 8px 0;
+        position: relative;
+        padding-left: 30%;
+    }
+
+    .dataTable td:before {
+        content: attr(data-label) ": ";
+        position: absolute;
+        left: 6px;
+        width: 25%;
+        padding-right: 10px;
+        white-space: nowrap;
+        font-weight: 600;
+        color: #6B7280;
+    }
+}
+
+@media (max-width: 480px) {
+    .page {
+        padding: 20px 10px;
+    }
+
+    .canvasContainer {
+        min-height: 250px;
+    }
+
+    .actionButtons {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .actionButton {
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---

## 변경 사항 
- 관리자 설정, 대시보드, 모니터링, 리포트, 위험구역 페이지들의 UI를 초기 구현하였습니다.
---
## 테스트 결과
- 대시보드
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/e6bdf4f6-c7fd-44a4-a31f-52ede5da4352" />

- 모니터링
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/6a5b2548-0343-44e2-b491-9140b804cad8" />

- 위험구역
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/e31fc586-0c5f-4436-8668-6fed2e224ca3" />

- 리포트
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/dc581af9-0c7a-48b6-ac5a-ab0e0a86b265" />

<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/31a4172c-8652-435e-8383-3d13fe1b1d60" />


