### PR TITLE
fix: 도면 등록 multipart 방식으로 변경 

### DIFF
--- a/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
@@ -3,6 +3,7 @@ package com.iroom.dashboard.controller;
 import com.iroom.dashboard.dto.request.BlueprintRequest;
 import com.iroom.dashboard.dto.response.BlueprintResponse;
 import com.iroom.dashboard.service.BlueprintService;
+import com.iroom.modulecommon.dto.response.ApiResponse;
 import com.iroom.modulecommon.dto.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -23,11 +24,11 @@ public class BlueprintController {
 
 	// 도면 등록
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<BlueprintResponse> createBlueprint(
+	public ResponseEntity<ApiResponse<BlueprintResponse>> createBlueprint(
 		@RequestPart("file") MultipartFile file,
 		@RequestPart("data") BlueprintRequest blueprintUrl) {
 		BlueprintResponse response = blueprintService.createBlueprint(file, blueprintUrl);
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	// 도면 수정

--- a/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/controller/BlueprintController.java
@@ -7,8 +7,10 @@ import com.iroom.modulecommon.dto.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -20,9 +22,11 @@ public class BlueprintController {
 	private final BlueprintService blueprintService;
 
 	// 도면 등록
-	@PostMapping
-	public ResponseEntity<BlueprintResponse> createBlueprint(@RequestBody BlueprintRequest request) {
-		BlueprintResponse response = blueprintService.createBlueprint(request);
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<BlueprintResponse> createBlueprint(
+		@RequestPart("file") MultipartFile file,
+		@RequestPart("data") BlueprintRequest blueprintUrl) {
+		BlueprintResponse response = blueprintService.createBlueprint(file, blueprintUrl);
 		return ResponseEntity.ok(response);
 	}
 

--- a/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
@@ -40,11 +40,19 @@ public class BlueprintService {
 
 		File directory = new File(saveDirPath);
 		if (!directory.exists()) {
-			directory.mkdirs();
+			boolean created = directory.mkdirs();
+			if (!created) {
+				throw new RuntimeException("디렉토리 생성 실패");
+			}
 		}
 
-		String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
-		String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
+		String originalFilename = file.getOriginalFilename();
+		if (originalFilename == null) {
+			throw new IllegalArgumentException("파일이 선택되지 않았습니다.");
+		}
+		
+		String cleanedFilename = StringUtils.cleanPath(originalFilename);
+		String fileExtension = cleanedFilename.substring(cleanedFilename.lastIndexOf("."));
 		String storedFilename = UUID.randomUUID() + fileExtension;
 
 		File destFile = new File(directory, storedFilename);

--- a/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/service/BlueprintService.java
@@ -1,5 +1,10 @@
 package com.iroom.dashboard.service;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.UUID;
+
 import com.iroom.dashboard.dto.request.BlueprintRequest;
 import com.iroom.dashboard.dto.response.BlueprintResponse;
 import com.iroom.dashboard.entity.Blueprint;
@@ -7,6 +12,7 @@ import com.iroom.dashboard.repository.BlueprintRepository;
 import com.iroom.modulecommon.dto.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,6 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -22,10 +30,35 @@ public class BlueprintService {
 
 	private final BlueprintRepository blueprintRepository;
 
+	@Value("${app.upload-dir}")
+	private String uploadDir;
+
 	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
-	public BlueprintResponse createBlueprint(BlueprintRequest request) {
+	public BlueprintResponse createBlueprint(MultipartFile file,BlueprintRequest request) {
+		String rootPath = System.getProperty("user.dir");
+		String saveDirPath = Paths.get(rootPath, uploadDir).toString();
+
+		File directory = new File(saveDirPath);
+		if (!directory.exists()) {
+			directory.mkdirs();
+		}
+
+		String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+		String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
+		String storedFilename = UUID.randomUUID() + fileExtension;
+
+		File destFile = new File(directory, storedFilename);
+		try {
+			file.transferTo(destFile);
+		} catch (IOException e) {
+			throw new RuntimeException("도면 파일 저장 중 오류 발생", e);
+		}
+
+		// 저장된 정적 파일의 접근 경로(URL)
+		String blueprintUrl = "/uploads/blueprints/" + storedFilename;
+
 		Blueprint blueprint = Blueprint.builder()
-			.blueprintUrl(request.blueprintUrl())
+			.blueprintUrl(blueprintUrl)
 			.floor(request.floor())
 			.width(request.width())
 			.height(request.height())

--- a/dashboard/src/main/resources/application.yml
+++ b/dashboard/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
       max-file-size: 500MB
       max-request-size: 500MB
 
+  web:
+    resources:
+      static-locations: file:uploads/
+
+app:
+  upload-dir: uploads/blueprints
 
 openai: #gpt api
   model:

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -69,10 +69,10 @@ class BlueprintControllerTest {
 				.file(data)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.blueprintUrl").value("/uploads/blueprints/test-uuid.png"))
-			.andExpect(jsonPath("$.floor").value(1))
-			.andExpect(jsonPath("$.width").value(100.0))
-			.andExpect(jsonPath("$.height").value(200.0));
+			.andExpect(jsonPath("$.data.blueprintUrl").value("/uploads/blueprints/test-uuid.png"))
+			.andExpect(jsonPath("$.data.floor").value(1))
+			.andExpect(jsonPath("$.data.width").value(100.0))
+			.andExpect(jsonPath("$.data.height").value(200.0));
 	}
 
 	@Test

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -18,7 +19,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -26,8 +29,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(BlueprintController.class)
-@Import(BlueprintControllerTest.MockConfig.class)
+@WebMvcTest(value = BlueprintController.class, excludeAutoConfiguration = {
+	org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
+@AutoConfigureMockMvc(addFilters = false)
 class BlueprintControllerTest {
 
 	@Autowired
@@ -49,18 +53,26 @@ class BlueprintControllerTest {
 	@DisplayName("도면 등록 성공")
 	void createBlueprintTest() throws Exception {
 		// given
-		BlueprintRequest request = new BlueprintRequest("url.png", 1, 100.0, 200.0);
-		BlueprintResponse response = new BlueprintResponse(1L, "url.png", 1, 100.0, 200.0);
+		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		BlueprintResponse response = new BlueprintResponse(1L, "/uploads/blueprints/test-uuid.png", 1, 100.0, 200.0);
 
-		Mockito.when(blueprintService.createBlueprint(any())).thenReturn(response);
+		MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", "test content".getBytes());
+		MockMultipartFile data = new MockMultipartFile("data", "", "application/json", 
+			objectMapper.writeValueAsString(request).getBytes());
+
+		Mockito.when(blueprintService.createBlueprint(any(MultipartFile.class), any(BlueprintRequest.class)))
+			.thenReturn(response);
 
 		// when & then
-		mockMvc.perform(post("/blueprints")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
+		mockMvc.perform(multipart("/blueprints")
+				.file(file)
+				.file(data)
+				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.blueprintUrl").value("url.png"))
-			.andExpect(jsonPath("$.floor").value(1));
+			.andExpect(jsonPath("$.blueprintUrl").value("/uploads/blueprints/test-uuid.png"))
+			.andExpect(jsonPath("$.floor").value(1))
+			.andExpect(jsonPath("$.width").value(100.0))
+			.andExpect(jsonPath("$.height").value(200.0));
 	}
 
 	@Test

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -3,6 +3,7 @@ package com.iroom.dashboard.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +18,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.iroom.dashboard.dto.request.BlueprintRequest;
 import com.iroom.dashboard.dto.response.BlueprintResponse;
@@ -36,18 +40,21 @@ class BlueprintServiceTest {
 	private Blueprint blueprint;
 	private Pageable pageable;
 	private Page<Blueprint> blueprintPage;
+	private MultipartFile validFile;
+	private MultipartFile invalidFile;
+	private MultipartFile nullNameFile;
 
 	@BeforeEach
 	void setUp() {
 		blueprint = Blueprint.builder()
-			.blueprintUrl("url.png")
+			.blueprintUrl("/uploads/blueprints/test-uuid.png")
 			.floor(1)
 			.width(100.0)
 			.height(200.0)
 			.build();
 
 		Blueprint blueprint2 = Blueprint.builder()
-			.blueprintUrl("url2.png")
+			.blueprintUrl("/uploads/blueprints/test-uuid2.png")
 			.floor(2)
 			.width(150.0)
 			.height(250.0)
@@ -55,21 +62,89 @@ class BlueprintServiceTest {
 
 		pageable = PageRequest.of(0, 10);
 		blueprintPage = new PageImpl<>(List.of(blueprint, blueprint2), pageable, 2);
+		
+		// 테스트용 파일 생성
+		validFile = new MockMultipartFile(
+			"file",
+			"test-blueprint.png",
+			"image/png",
+			"test image content".getBytes()
+		);
+		
+		invalidFile = new MockMultipartFile(
+			"file",
+			"test-blueprint", // 확장자 없음
+			"text/plain",
+			"test content".getBytes()
+		);
+		
+		nullNameFile = new MockMultipartFile(
+			"file",
+			null, // null 파일명
+			"image/png",
+			"test content".getBytes()
+		);
+		
+		// upload-dir 설정
+		ReflectionTestUtils.setField(blueprintService, "uploadDir", "uploads/blueprints");
 	}
 
 	@Test
 	@DisplayName("도면 생성 성공")
 	void createBlueprintTest() {
 		// given
-		BlueprintRequest request = new BlueprintRequest("url.png", 1, 100.0, 200.0);
+		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
 		given(blueprintRepository.save(any(Blueprint.class))).willReturn(blueprint);
 
 		// when
-		BlueprintResponse response = blueprintService.createBlueprint(request);
+		BlueprintResponse response = blueprintService.createBlueprint(validFile, request);
 
 		// then
-		assertThat(response.blueprintUrl()).isEqualTo("url.png");
+		assertThat(response.blueprintUrl()).contains("/uploads/blueprints/");
+		assertThat(response.blueprintUrl()).contains(".png");
 		assertThat(response.floor()).isEqualTo(1);
+		assertThat(response.width()).isEqualTo(100.0);
+		assertThat(response.height()).isEqualTo(200.0);
+		verify(blueprintRepository).save(any(Blueprint.class));
+	}
+	
+	@Test
+	@DisplayName("도면 생성 실패 - 파일명이 null")
+	void createBlueprintFailNullFilename() {
+		// given
+		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+
+		// when & then
+		assertThatThrownBy(() -> blueprintService.createBlueprint(nullNameFile, request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("파일명이 유효하지 않습니다.");
+	}
+	
+	@Test
+	@DisplayName("도면 생성 실패 - 파일 확장자 없음")
+	void createBlueprintFailNoExtension() {
+		// given
+		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+
+		// when & then
+		assertThatThrownBy(() -> blueprintService.createBlueprint(invalidFile, request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("파일 확장자가 없습니다.");
+	}
+	
+	@Test
+	@DisplayName("도면 생성 실패 - 디렉토리 생성 실패")
+	void createBlueprintFailDirectoryCreation() {
+		// given
+		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		
+		// 디렉토리 생성이 실패하는 시나리오를 위해 읽기 전용 경로 설정
+		ReflectionTestUtils.setField(blueprintService, "uploadDir", "/invalid/readonly/path");
+
+		// when & then
+		assertThatThrownBy(() -> blueprintService.createBlueprint(validFile, request))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("디렉토리 생성 실패");
 	}
 
 	@Test

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -293,10 +293,30 @@ export const blueprintAPI = {
     createBlueprint: async (blueprintData) => {
         const url = `${API_CONFIG.gateway}/api/dashboard/blueprints`;
         console.log('[도면등록 요청 URL]', url);
-        console.log('[도면등록 데이터]', blueprintData);
-        return await apiRequest(url, {
-            method: 'POST',
-            body: JSON.stringify(blueprintData)
+
+        const formData = new FormData();
+
+        // 도면 정보(JSON)를 Blob으로 감싸서 전달
+        const dataBlob = new Blob(
+            [JSON.stringify({
+                blueprintUrl: "", // 백엔드에서 파일 저장 후 경로 재설정하므로 빈 값
+                floor: blueprintData.floor,
+                width: blueprintData.width,
+                height: blueprintData.height
+            })],
+            { type: "application/json" }
+        );
+        formData.append("data", dataBlob);
+
+        // 파일 첨부
+        formData.append("file", blueprintData.file);
+
+        return await fetch(url, {
+            method: "POST",
+            headers: {
+                Authorization: authUtils.getAuthHeader()
+            },
+            body: formData
         });
     },
 };

--- a/frontend/src/components/WorkerAddModal.js
+++ b/frontend/src/components/WorkerAddModal.js
@@ -1,20 +1,23 @@
 import React, { useState } from 'react';
 
 const WorkerAddModal = ({ isOpen, onClose, onSave }) => {
-    const [addForm, setAddForm] = useState({
-        name: '',
-        department: '',
-        occupation: '',
-        phone: '',
-        bloodType: '',
-        jobTitle: '',
-        age: '',
-        weight: '',
-        height: '',
-        email: '',
+    // 테스트용 초기값 정의
+    const initialFormData = {
+        name: '김철수',
+        department: '건설부',
+        occupation: '현장 작업자',
+        phone: '010-1234-5678',
+        bloodType: 'A',
+        jobTitle: '팀장',
+        age: '35',
+        weight: '75.5',
+        height: '175.0',
+        email: 'test@example.com',
         gender: 'MALE',
-        password: ''
-    });
+        password: 'password123'
+    };
+
+    const [addForm, setAddForm] = useState(initialFormData);
 
     const handleInputChange = (e) => {
         const { name, value } = e.target;
@@ -95,39 +98,13 @@ const WorkerAddModal = ({ isOpen, onClose, onSave }) => {
         }
 
         onSave(addForm);
-        // 폼 초기화
-        setAddForm({
-            name: '',
-            department: '',
-            occupation: '',
-            phone: '',
-            bloodType: '',
-            jobTitle: '',
-            age: '',
-            weight: '',
-            height: '',
-            email: '',
-            gender: 'MALE',
-            password: ''
-        });
+        // 폼을 예시값으로 초기화
+        setAddForm(initialFormData);
     };
 
     const handleClose = () => {
-        // 폼 초기화
-        setAddForm({
-            name: '',
-            department: '',
-            occupation: '',
-            phone: '',
-            bloodType: '',
-            jobTitle: '',
-            age: '',
-            weight: '',
-            height: '',
-            email: '',
-            gender: 'MALE',
-            password: ''
-        });
+        // 폼을 예시값으로 초기화
+        setAddForm(initialFormData);
         onClose();
     };
 

--- a/frontend/src/pages/AdminLogin.js
+++ b/frontend/src/pages/AdminLogin.js
@@ -4,8 +4,8 @@ import {adminAPI} from '../api/api';
 
 const AdminLogin = ({onLogin}) => {
     const [formData, setFormData] = useState({
-        email: '',
-        password: ''
+        email: 'admin@iroom.com',
+        password: 'admin123!'
     });
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -57,3 +57,9 @@ spring:
               filters:
                 - JwtAuthenticationFilter
                 - RewritePath=/api/dashboard/(?<segment>.*), /$\{segment}
+            - id: dashboard-static-route
+              uri: http://localhost:8085
+              predicates:
+                - Path=/uploads/**
+              filters:
+                - StripPrefix=0


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---

## 변경 사항 
- 로그인, 근로자 등록 입력폼에 예시값을 추가하였습니다.
- 도면 등록 기능을 multipart/form-data 방식으로 변경하여 이미지 파일과 메타데이터를 함께 업로드할 수 있도록 수정하였습니다.  
- 기존의 blueprintUrl 기반 등록 방식을 제거하고, 실제 파일을 서버에 저장한 후 경로를 DB에 저장하는 구조로 개선하였습니다.  
- Gateway 라우팅, 저장 디렉토리 설정, 프론트 FormData 전송 방식, 백엔드 Controller 및 Service 로직을 함께 수정하였습니다.
- 도면 등록 테스트 코드를 수정하였습니다.

- Gateway: 도면 등록 경로(`/api/dashboard/blueprints`)에 대한 라우팅 설정
- application.yml: 업로드 경로(`uploads/blueprints`) 및 정적 리소스 접근 설정 추가

---
## 테스트 결과
<img width="523" height="203" alt="image" src="https://github.com/user-attachments/assets/1460b467-8587-43af-bc58-4c8da02262b0" />

- postman (`POST localhost:8080/api/dashboard/blueprints`)
<img width="2345" height="439" alt="image" src="https://github.com/user-attachments/assets/78af8542-712d-41cd-9505-46c5a052fdac" />
<img width="1881" height="404" alt="image" src="https://github.com/user-attachments/assets/31f7da88-f634-4014-9f7a-bf64349898c4" />

