### PR TITLE
feat: 장비 센서 서비스 고도화 및 테스트 코드 수정

### DIFF
--- a/sensor/src/main/java/com/iroom/sensor/controller/HeavyEquipmentController.java
+++ b/sensor/src/main/java/com/iroom/sensor/controller/HeavyEquipmentController.java
@@ -27,9 +27,9 @@ public class HeavyEquipmentController {
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
-	@PutMapping("/location")
+	@PutMapping(value = "/location", consumes = "application/octet-stream")
 	public ResponseEntity<ApiResponse<EquipmentUpdateLocationResponse>> updateLocation(
-		@RequestBody EquipmentUpdateLocationRequest request
+		@RequestBody byte[] binaryData
 	) {
 		EquipmentUpdateLocationResponse response = heavyEquipmentService.updateLocation(request);
 		return ResponseEntity.ok(ApiResponse.success(response));

--- a/sensor/src/main/java/com/iroom/sensor/controller/HeavyEquipmentController.java
+++ b/sensor/src/main/java/com/iroom/sensor/controller/HeavyEquipmentController.java
@@ -31,7 +31,7 @@ public class HeavyEquipmentController {
 	public ResponseEntity<ApiResponse<EquipmentUpdateLocationResponse>> updateLocation(
 		@RequestBody byte[] binaryData
 	) {
-		EquipmentUpdateLocationResponse response = heavyEquipmentService.updateLocation(request);
+		EquipmentUpdateLocationResponse response = heavyEquipmentService.updateLocation(binaryData);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 

--- a/sensor/src/main/java/com/iroom/sensor/service/HeavyEquipmentService.java
+++ b/sensor/src/main/java/com/iroom/sensor/service/HeavyEquipmentService.java
@@ -55,7 +55,9 @@ public class HeavyEquipmentService {
 
 	//위치 업데이트 기능
 	@PreAuthorize("hasAuthority('ROLE_EQUIPMENT_SYSTEM')")
-	public EquipmentUpdateLocationResponse updateLocation(EquipmentUpdateLocationRequest request) {
+	public EquipmentUpdateLocationResponse updateLocation(byte[] binaryData) {
+		EquipmentUpdateLocationRequest request = parseBinaryData(binaryData);
+
 		HeavyEquipment equipment = heavyEquipmentRepository.findById(request.id())
 			.orElseThrow(() -> new CustomException(ErrorCode.SENSOR_EQUIPMENT_NOT_FOUND));
 

--- a/sensor/src/main/java/com/iroom/sensor/service/HeavyEquipmentService.java
+++ b/sensor/src/main/java/com/iroom/sensor/service/HeavyEquipmentService.java
@@ -1,5 +1,8 @@
 package com.iroom.sensor.service;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+
 import com.iroom.modulecommon.exception.CustomException;
 import com.iroom.modulecommon.exception.ErrorCode;
 import com.iroom.modulecommon.service.KafkaProducerService;
@@ -9,6 +12,7 @@ import com.iroom.sensor.dto.HeavyEquipment.EquipmentRegisterRequest;
 import com.iroom.sensor.dto.HeavyEquipment.EquipmentRegisterResponse;
 import com.iroom.modulecommon.dto.event.EquipmentEvent;
 import com.iroom.modulecommon.dto.event.EquipmentLocationEvent;
+import com.iroom.sensor.dto.WorkerSensor.WorkerSensorUpdateRequest;
 import com.iroom.sensor.entity.HeavyEquipment;
 import com.iroom.sensor.repository.HeavyEquipmentRepository;
 
@@ -71,6 +75,22 @@ public class HeavyEquipmentService {
 
 		return new EquipmentUpdateLocationResponse(equipment.getId(), equipment.getLatitude(),
 			equipment.getLongitude());
+	}
+
+	private EquipmentUpdateLocationRequest parseBinaryData(byte [] binaryData) {
+		try (ByteArrayInputStream bis = new ByteArrayInputStream(binaryData);
+			 DataInputStream dis = new DataInputStream(bis)) {
+
+			Long id = dis.readLong();
+			Double latitude = dis.readDouble();
+			Double longitude = dis.readDouble();
+
+			validateCoordinates(latitude, longitude);
+
+			return new EquipmentUpdateLocationRequest(id, latitude, longitude);
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.SENSOR_INVALID_BINARY_DATA);
+		}
 	}
 
 	private void validateCoordinates(Double latitude, Double longitude) {


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- 장비 위치 업데이트 기능을 JSON → binary(application/octet-stream) 방식으로 변경하였습니다.

- 기존의 EquipmentUpdateLocationRequest를 이용한 JSON 본문 전송 방식을 제거하고,
- 클라이언트에서 DataOutputStream을 통해 바이너리 데이터(equipmentId, latitude, longitude)를 전송하도록 수정하였습니다.

- 서버에서는 @RequestBody byte[]로 데이터를 수신하고,
Service 내부에서 DataInputStream을 사용해 값을 파싱하여 도메인 로직에 반영하도록 개선하였습니다.

- Controller, Service, DTO 구조를 바이너리 방식에 맞게 리팩토링하였으며, equipmentId는 헤더가 아닌 바디 내에서 직접 추출하여 처리하도록 변경하였습니다.

- Spring Security 권한 설정(ROLE_EQUIPMENT_SYSTEM) 및 인증 방식은 유지하면서,
개별 장비 식별은 전송된 바이너리 내 id값을 통해 처리합니다.

- 기존 테스트 코드(JSON 기반)를 제거하고,
application/octet-stream 형식으로 바이너리 요청을 테스트하는 코드로 모두 교체하였습니다.

- 테스트를 위해 바이너리 데이터 생성 유틸(createBinaryData(...))을 추가하여
equipmentId, latitude, longitude 값을 순서대로 직렬화하도록 하였습니다.
---