### PR TITLE
feat: 근로자 위치 데이터 파이썬 서버로 전송 구현

### DIFF
--- a/sensor/src/main/java/com/iroom/sensor/service/WorkerSensorService.java
+++ b/sensor/src/main/java/com/iroom/sensor/service/WorkerSensorService.java
@@ -12,17 +12,22 @@ import com.iroom.sensor.repository.WorkerSensorRepository;
 import com.iroom.sensor.repository.WorkerReadModelRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class WorkerSensorService {
 
 	private final KafkaProducerService kafkaProducerService;
@@ -115,6 +120,22 @@ public class WorkerSensorService {
 		}
 		if (stepPerMinute != null && stepPerMinute < 0) {
 			throw new CustomException(ErrorCode.SENSOR_INVALID_BIOMETRIC_DATA);
+		}
+	}
+
+	private void sendGpsToPythonServer(Double latitude, Double longitude, Long workerId) {
+		RestTemplate restTemplate = new RestTemplate();
+
+		Map<String, Object> gpsData = new HashMap<>();
+		gpsData.put("workerId", workerId);
+		gpsData.put("latitude", latitude);
+		gpsData.put("longitude", longitude);
+
+		try {
+			restTemplate.postForEntity("http://localhost:8000/gps/", gpsData, String.class);
+			log.info("Python 서버에 GPS 전송 완료: {}", gpsData);
+		} catch (Exception e) {
+			log.error("Python 서버 GPS 전송 실패", e);
 		}
 	}
 }

--- a/sensor/src/main/java/com/iroom/sensor/service/WorkerSensorService.java
+++ b/sensor/src/main/java/com/iroom/sensor/service/WorkerSensorService.java
@@ -64,6 +64,8 @@ public class WorkerSensorService {
 
 		kafkaProducerService.publishMessage("WORKER_SENSOR_UPDATED", workerSensorEvent);
 
+		sendGpsToPythonServer(request.latitude(), request.longitude(), workerId);
+
 		return new WorkerSensorUpdateResponse(workerSensor);
 	}
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 변경 사항
- `WorkerSensorService`에서 파이썬 서버로 근로자 위치 데이터 전송 구현
   - api 전송 메서드 생성(`sendGpsToPythonServer`) ->  "http://localhost:8000/gps/" 로 전송
   - 근로자 센서 업데이트(`updateSensor`)시 센서 전송됨

---
## 테스트 결과
- **sensor 서비스 로그**
<img width="598" height="29" alt="image" src="https://github.com/user-attachments/assets/bd9a79fc-1762-427a-8ea7-828f73878cb4" />

- **iroom_ppe DB 저장**
    - <img width="341" height="105" alt="image" src="https://github.com/user-attachments/assets/d5a788af-7a64-4b05-84fc-57ae98cc4431" />

   - 현재 로컬에서 모델이 돌아가지 않아, api로 전송할 경우 DB에 저장되는지, 5초마다 날라가는 지만 확인함.
   - 또한, 현재 파이썬 서버에서 위치 업데이트가 아닌 계속 저장되는 형식으로 되어 있어, 이후 수정해서 재 테스트 필요
 
---
## 추가 전달 사항
 - 근로자 센서 서비스 PUT 변경 후 데이터 업데이트 및 카프카 발행 확인 되었음. 