### PR TITLE
feat: 위험구역 페이지 백엔드 연동 및 푸터 추가

### DIFF
--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/controller/BlueprintController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/controller/BlueprintController.java
@@ -51,6 +51,13 @@ public class BlueprintController {
 		return ResponseEntity.ok(ApiResponse.success(result));
 	}
 
+	// 도면 단일 조회
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<BlueprintResponse>> getBlueprint(@PathVariable Long id) {
+		BlueprintResponse response = blueprintService.getBlueprint(id);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
 	// 도면 전체 조회
 	@GetMapping
 	public ResponseEntity<ApiResponse<PagedResponse<BlueprintResponse>>> getAllBlueprints(

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/controller/BlueprintController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/controller/BlueprintController.java
@@ -54,15 +54,20 @@ public class BlueprintController {
 	// 도면 전체 조회
 	@GetMapping
 	public ResponseEntity<ApiResponse<PagedResponse<BlueprintResponse>>> getAllBlueprints(
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
+		@RequestParam(required = false) String target,
+		@RequestParam(required = false) String keyword,
+		@RequestParam(defaultValue = "0") Integer page,
+		@RequestParam(defaultValue = "10") Integer size
 	) {
-		if (size > 50)
+		if (size > 50) {
 			size = 50;
-		if (size < 0)
-			size = 0;
+		}
 
-		PagedResponse<BlueprintResponse> responses = blueprintService.getAllBlueprints(page, size);
+		if (size < 0) {
+			size = 0;
+		}
+
+		PagedResponse<BlueprintResponse> responses = blueprintService.getAllBlueprints(target, keyword, page, size);
 		return ResponseEntity.ok(ApiResponse.success(responses));
 	}
 

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/repository/BlueprintRepository.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/repository/BlueprintRepository.java
@@ -2,10 +2,14 @@ package com.iroom.dashboard.blueprint.repository;
 
 import com.iroom.dashboard.blueprint.entity.Blueprint;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource(exported = false)
 public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
 
+    Page<Blueprint> findByFloor(Integer floor, Pageable pageable);
+    
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
@@ -165,10 +165,25 @@ public class BlueprintService {
 	}
 
 	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
-	public PagedResponse<BlueprintResponse> getAllBlueprints(int page, int size) {
+	public PagedResponse<BlueprintResponse> getAllBlueprints(String target, String keyword, Integer page, Integer size) {
 		Pageable pageable = PageRequest.of(page, size);
-		Page<Blueprint> blueprints = blueprintRepository.findAll(pageable);
-		Page<BlueprintResponse> responsePage = blueprints.map(BlueprintResponse::new);
+
+		Page<Blueprint> blueprintPage;
+		if (target == null || keyword == null || keyword.trim().isEmpty()) {
+			blueprintPage = blueprintRepository.findAll(pageable);
+		} else if ("floor".equals(target)) {
+			try {
+				Integer floor = Integer.parseInt(keyword);
+				blueprintPage = blueprintRepository.findByFloor(floor, pageable);
+			} catch (NumberFormatException e) {
+				blueprintPage = blueprintRepository.findAll(pageable);
+			}
+		} else {
+			blueprintPage = blueprintRepository.findAll(pageable);
+		}
+
+		Page<BlueprintResponse> responsePage = blueprintPage.map(BlueprintResponse::new);
+
 		return PagedResponse.of(responsePage);
 	}
 

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
@@ -165,6 +165,13 @@ public class BlueprintService {
 	}
 
 	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
+	public BlueprintResponse getBlueprint(Long id) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
+		return new BlueprintResponse(blueprint);
+	}
+
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
 	public PagedResponse<BlueprintResponse> getAllBlueprints(String target, String keyword, Integer page, Integer size) {
 		Pageable pageable = PageRequest.of(page, size);
 

--- a/dashboard/src/main/java/com/iroom/dashboard/danger/controller/DangerAreaController.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/danger/controller/DangerAreaController.java
@@ -3,6 +3,7 @@ package com.iroom.dashboard.danger.controller;
 import com.iroom.dashboard.danger.dto.request.DangerAreaRequest;
 import com.iroom.dashboard.danger.dto.response.DangerAreaResponse;
 import com.iroom.dashboard.danger.service.DangerAreaService;
+import com.iroom.modulecommon.dto.response.ApiResponse;
 import com.iroom.modulecommon.dto.response.PagedResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -19,24 +20,27 @@ public class DangerAreaController {
 	private final DangerAreaService dangerAreaService;
 
 	@PostMapping
-	public ResponseEntity<DangerAreaResponse> createDangerArea(@RequestBody DangerAreaRequest request) {
-		return ResponseEntity.ok(dangerAreaService.createDangerArea(request));
+	public ResponseEntity<ApiResponse<DangerAreaResponse>> createDangerArea(@RequestBody DangerAreaRequest request) {
+		DangerAreaResponse response = dangerAreaService.createDangerArea(request);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@PutMapping("/{id}")
-	public ResponseEntity<DangerAreaResponse> updateDangerArea(@PathVariable Long id,
+	public ResponseEntity<ApiResponse<DangerAreaResponse>> updateDangerArea(@PathVariable Long id,
 		@RequestBody DangerAreaRequest request) {
-		return ResponseEntity.ok(dangerAreaService.updateDangerArea(id, request));
+		DangerAreaResponse response = dangerAreaService.updateDangerArea(id, request);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Map<String, Object>> deleteDangerArea(@PathVariable Long id) {
+	public ResponseEntity<ApiResponse<Map<String, Object>>> deleteDangerArea(@PathVariable Long id) {
 		dangerAreaService.deleteDangerArea(id);
-		return ResponseEntity.ok(Map.of("message", "위험구역 삭제 완료", "deletedId", id));
+		Map<String, Object> result = Map.of("message", "위험구역 삭제 완료", "deletedId", id);
+		return ResponseEntity.ok(ApiResponse.success(result));
 	}
 
 	@GetMapping
-	public ResponseEntity<PagedResponse<DangerAreaResponse>> getAllDangerAreas(
+	public ResponseEntity<ApiResponse<PagedResponse<DangerAreaResponse>>> getAllDangerAreas(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size
 	) {
@@ -46,6 +50,6 @@ public class DangerAreaController {
 			size = 0;
 
 		PagedResponse<DangerAreaResponse> response = dangerAreaService.getAllDangerAreas(page, size);
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/danger/dto/request/DangerAreaRequest.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/danger/dto/request/DangerAreaRequest.java
@@ -5,6 +5,7 @@ public record DangerAreaRequest(
 	Double latitude,
 	Double longitude,
 	Double width,
-	Double height
+	Double height,
+	String name
 ) {
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/danger/dto/response/DangerAreaResponse.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/danger/dto/response/DangerAreaResponse.java
@@ -8,7 +8,8 @@ public record DangerAreaResponse(
 	Double latitude,
 	Double longitude,
 	Double width,
-	Double height
+	Double height,
+	String name
 ) {
 	public DangerAreaResponse(DangerArea entity) {
 		this(
@@ -17,7 +18,8 @@ public record DangerAreaResponse(
 			entity.getLatitude(),
 			entity.getLongitude(),
 			entity.getWidth(),
-			entity.getHeight()
+			entity.getHeight(),
+			entity.getName()
 		);
 	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/danger/entity/DangerArea.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/danger/entity/DangerArea.java
@@ -27,19 +27,24 @@ public class DangerArea {
 	@Column(nullable = false)
 	private Double height;
 
+	@Column(length = 100)
+	private String name;
+
 	@Builder
-	public DangerArea(Long blueprintId, Double latitude, Double longitude, Double width, Double height) {
+	public DangerArea(Long blueprintId, Double latitude, Double longitude, Double width, Double height, String name) {
 		this.blueprintId = blueprintId;
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.width = width;
 		this.height = height;
+		this.name = name;
 	}
 
-	public void update(Double latitude, Double longitude, Double width, Double height) {
+	public void update(Double latitude, Double longitude, Double width, Double height, String name) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.width = width;
 		this.height = height;
+		this.name = name;
 	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/danger/service/DangerAreaService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/danger/service/DangerAreaService.java
@@ -30,6 +30,7 @@ public class DangerAreaService {
 			.longitude(request.longitude())
 			.width(request.width())
 			.height(request.height())
+			.name(request.name())
 			.build();
 		return new DangerAreaResponse(dangerAreaRepository.save(dangerArea));
 	}
@@ -38,7 +39,7 @@ public class DangerAreaService {
 	public DangerAreaResponse updateDangerArea(Long id, DangerAreaRequest request) {
 		DangerArea dangerArea = dangerAreaRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 위험구역이 존재하지 않습니다."));
-		dangerArea.update(request.latitude(), request.longitude(), request.width(), request.height());
+		dangerArea.update(request.latitude(), request.longitude(), request.width(), request.height(), request.name());
 		return new DangerAreaResponse(dangerArea);
 	}
 

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -155,7 +155,7 @@ class BlueprintControllerTest {
 		Page<BlueprintResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), content.size());
 		PagedResponse<BlueprintResponse> pagedResponse = PagedResponse.of(page);
 
-		Mockito.when(blueprintService.getAllBlueprints(0, 10)).thenReturn(pagedResponse);
+		Mockito.when(blueprintService.getAllBlueprints(null, null, 0, 10)).thenReturn(pagedResponse);
 
 		// when & then
 		mockMvc.perform(get("/blueprints?page=0&size=10"))

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/DangerAreaControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/DangerAreaControllerTest.java
@@ -52,8 +52,8 @@ class DangerAreaControllerTest {
 	@DisplayName("위험구역 등록 성공")
 	void createDangerAreaTest() throws Exception {
 		// given
-		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 20.0, 100.0, 200.0);
-		DangerAreaResponse response = new DangerAreaResponse(1L, 1L, 10.0, 20.0, 100.0, 200.0);
+		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 20.0, 100.0, 200.0, "테스트 위험구역");
+		DangerAreaResponse response = new DangerAreaResponse(1L, 1L, 10.0, 20.0, 100.0, 200.0, "테스트 위험구역");
 
 		Mockito.when(dangerAreaService.createDangerArea(any())).thenReturn(response);
 
@@ -62,17 +62,18 @@ class DangerAreaControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.latitude").value(10.0))
-			.andExpect(jsonPath("$.longitude").value(20.0))
-			.andExpect(jsonPath("$.blueprintId").value(1));
+			.andExpect(jsonPath("$.data.latitude").value(10.0))
+			.andExpect(jsonPath("$.data.longitude").value(20.0))
+			.andExpect(jsonPath("$.data.blueprintId").value(1))
+			.andExpect(jsonPath("$.data.name").value("테스트 위험구역"));
 	}
 
 	@Test
 	@DisplayName("위험구역 수정 성공")
 	void updateDangerAreaTest() throws Exception {
 		// given
-		DangerAreaRequest request = new DangerAreaRequest(1L, 99.0, 88.0, 120.0, 220.0);
-		DangerAreaResponse response = new DangerAreaResponse(1L, 1L, 99.0, 88.0, 120.0, 220.0);
+		DangerAreaRequest request = new DangerAreaRequest(1L, 99.0, 88.0, 120.0, 220.0, "수정된 위험구역");
+		DangerAreaResponse response = new DangerAreaResponse(1L, 1L, 99.0, 88.0, 120.0, 220.0, "수정된 위험구역");
 
 		Mockito.when(dangerAreaService.updateDangerArea(eq(1L), any())).thenReturn(response);
 
@@ -81,9 +82,10 @@ class DangerAreaControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.latitude").value(99.0))
-			.andExpect(jsonPath("$.longitude").value(88.0))
-			.andExpect(jsonPath("$.width").value(120.0));
+			.andExpect(jsonPath("$.data.latitude").value(99.0))
+			.andExpect(jsonPath("$.data.longitude").value(88.0))
+			.andExpect(jsonPath("$.data.width").value(120.0))
+			.andExpect(jsonPath("$.data.name").value("수정된 위험구역"));
 	}
 
 	@Test
@@ -95,16 +97,16 @@ class DangerAreaControllerTest {
 		// when & then
 		mockMvc.perform(delete("/danger-areas/1"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value("위험구역 삭제 완료"))
-			.andExpect(jsonPath("$.deletedId").value(1));
+			.andExpect(jsonPath("$.data.message").value("위험구역 삭제 완료"))
+			.andExpect(jsonPath("$.data.deletedId").value(1));
 	}
 
 	@Test
 	@DisplayName("위험구역 전체 조회 성공")
 	void getAllDangerAreasTest() throws Exception {
 		// given
-		DangerAreaResponse r1 = new DangerAreaResponse(1L, 1L, 10.0, 20.0, 100.0, 200.0);
-		DangerAreaResponse r2 = new DangerAreaResponse(2L, 1L, 30.0, 40.0, 150.0, 250.0);
+		DangerAreaResponse r1 = new DangerAreaResponse(1L, 1L, 10.0, 20.0, 100.0, 200.0, "위험구역1");
+		DangerAreaResponse r2 = new DangerAreaResponse(2L, 1L, 30.0, 40.0, 150.0, 250.0, "위험구역2");
 
 		List<DangerAreaResponse> content = List.of(r1, r2);
 		Page<DangerAreaResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), content.size());
@@ -115,9 +117,10 @@ class DangerAreaControllerTest {
 		// when & then
 		mockMvc.perform(get("/danger-areas?page=0&size=10"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.content").isArray())
-			.andExpect(jsonPath("$.content.length()").value(2))
-			.andExpect(jsonPath("$.content[0].latitude").value(10.0))
-			.andExpect(jsonPath("$.content[0].longitude").value(20.0));
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.content[0].latitude").value(10.0))
+			.andExpect(jsonPath("$.data.content[0].longitude").value(20.0))
+			.andExpect(jsonPath("$.data.content[0].name").value("위험구역1"));
 	}
 }

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -304,7 +304,7 @@ class BlueprintServiceTest {
 		given(blueprintRepository.findAll(pageable)).willReturn(blueprintPage);
 
 		// when
-		PagedResponse<BlueprintResponse> response = blueprintService.getAllBlueprints(0, 10);
+		PagedResponse<BlueprintResponse> response = blueprintService.getAllBlueprints(null, null, 0, 10);
 
 		// then
 		assertThat(response.content()).hasSize(2);

--- a/dashboard/src/test/java/com/iroom/dashboard/service/DangerAreaServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/DangerAreaServiceTest.java
@@ -48,6 +48,7 @@ class DangerAreaServiceTest {
 			.longitude(20.0)
 			.width(100.0)
 			.height(200.0)
+			.name("테스트 위험구역")
 			.build();
 
 		DangerArea dangerArea2 = DangerArea.builder()
@@ -56,6 +57,7 @@ class DangerAreaServiceTest {
 			.longitude(60.0)
 			.width(150.0)
 			.height(250.0)
+			.name("테스트 위험구역2")
 			.build();
 
 		pageable = PageRequest.of(0, 10);
@@ -66,7 +68,7 @@ class DangerAreaServiceTest {
 	@DisplayName("위험구역 등록 성공")
 	void createDangerAreaTest() {
 		// given
-		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 20.0, 100.0, 200.0);
+		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 20.0, 100.0, 200.0, "테스트 위험구역");
 		given(dangerAreaRepository.save(any(DangerArea.class))).willReturn(dangerArea);
 
 		// when
@@ -76,6 +78,7 @@ class DangerAreaServiceTest {
 		assertThat(response.blueprintId()).isEqualTo(1L);
 		assertThat(response.latitude()).isEqualTo(10.0);
 		assertThat(response.longitude()).isEqualTo(20.0);
+		assertThat(response.name()).isEqualTo("테스트 위험구역");
 	}
 
 	@Test
@@ -83,7 +86,7 @@ class DangerAreaServiceTest {
 	void updateDangerAreaTest() {
 		// given
 		Long id = 1L;
-		DangerAreaRequest request = new DangerAreaRequest(1L, 99.0, 88.0, 300.0, 400.0);
+		DangerAreaRequest request = new DangerAreaRequest(1L, 99.0, 88.0, 300.0, 400.0, "수정된 위험구역");
 		given(dangerAreaRepository.findById(id)).willReturn(Optional.of(dangerArea));
 
 		// when
@@ -94,6 +97,7 @@ class DangerAreaServiceTest {
 		assertThat(response.longitude()).isEqualTo(88.0);
 		assertThat(response.width()).isEqualTo(300.0);
 		assertThat(response.height()).isEqualTo(400.0);
+		assertThat(response.name()).isEqualTo("수정된 위험구역");
 	}
 
 	@Test
@@ -101,7 +105,7 @@ class DangerAreaServiceTest {
 	void updateDangerAreaFail_NotFound() {
 		// given
 		Long id = 999L;
-		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 10.0, 100.0, 100.0);
+		DangerAreaRequest request = new DangerAreaRequest(1L, 10.0, 10.0, 100.0, 100.0, "테스트");
 		given(dangerAreaRepository.findById(id)).willReturn(Optional.empty());
 
 		// when & then

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,8 +2,17 @@
   min-height: 100vh;
   background-color: #f3f4f6;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
 }
 
 .layout-container {
   display: flex;
+  flex: 1;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,6 @@ import React, {useState} from 'react';
 import {BrowserRouter as Router, Navigate, Route, Routes, useNavigate} from 'react-router-dom';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
-import Footer from './components/Footer';
 import AdminLogin from './pages/AdminLogin';
 import AdminSignUpPage from './pages/AdminSignUpPage';
 import PrivacyConsentPage from './pages/PrivacyConsentPage';
@@ -48,7 +47,6 @@ const CommonLayout = ({ children, currentPage }) => {
                 <Sidebar activeItem={activeItem} setActiveItem={handleSidebarClick}/>
                 <div className="main-content">
                     {children}
-                    <Footer/>
                 </div>
             </div>
         </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {BrowserRouter as Router, Navigate, Route, Routes, useNavigate} from 'react-router-dom';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
+import Footer from './components/Footer';
 import AdminLogin from './pages/AdminLogin';
 import AdminSignUpPage from './pages/AdminSignUpPage';
 import PrivacyConsentPage from './pages/PrivacyConsentPage';
@@ -45,7 +46,10 @@ const CommonLayout = ({ children, currentPage }) => {
             <Header/>
             <div className="layout-container">
                 <Sidebar activeItem={activeItem} setActiveItem={handleSidebarClick}/>
-                {children}
+                <div className="main-content">
+                    {children}
+                    <Footer/>
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -361,6 +361,17 @@ export const userAPI = {
         });
     },
 
+    /**
+     * 관리자 삭제
+     * @param {string} adminId - 삭제할 관리자 ID
+     * @returns {Promise} 삭제 응답
+     */
+    deleteAdmin: async (adminId) => {
+        const url = `${API_CONFIG.gateway}/api/user/admins/${adminId}`;
+        return await apiRequest(url, {
+            method: 'DELETE'
+        });
+    },
 };
 
 /**

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -346,6 +346,21 @@ export const userAPI = {
         const url = `${API_CONFIG.gateway}/api/user/admins?${queryParams.toString()}`;
         return await apiRequest(url);
     },
+
+    /**
+     * 관리자 권한 변경
+     * @param {string} adminId - 관리자 ID
+     * @param {string} role - 새로운 권한 (SUPER_ADMIN, READER)
+     * @returns {Promise} 변경된 관리자 정보
+     */
+    changeAdminRole: async (adminId, role) => {
+        const url = `${API_CONFIG.gateway}/api/user/admins/${adminId}/role`;
+        return await apiRequest(url, {
+            method: 'PUT',
+            body: JSON.stringify({ role })
+        });
+    },
+
 };
 
 /**

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -551,3 +551,76 @@ export const blueprintAPI = {
         });
     }
 };
+
+/**
+ * Risk Zone (Danger Area) API 서비스
+ */
+export const riskZoneAPI = {
+    /**
+     * 위험구역 목록 조회
+     * @param {object} options
+     * @param {number} options.page - 페이지 번호 (기본값: 0)
+     * @param {number} options.size - 페이지당 개수 (기본값: 10)
+     * @returns {Promise} 위험구역 목록 데이터
+     */
+    getRiskZones: async ({page = 0, size = 10} = {}) => {
+        const queryParams = new URLSearchParams({
+            page: page.toString(),
+            size: size.toString(),
+        });
+
+        const url = `${API_CONFIG.gateway}/api/dashboard/danger-areas?${queryParams.toString()}`;
+        return await apiRequest(url);
+    },
+
+    /**
+     * 위험구역 등록
+     * @param {object} dangerAreaData - 등록할 위험구역 데이터
+     * @param {number} dangerAreaData.blueprintId - 도면 ID
+     * @param {number} dangerAreaData.latitude - 위도
+     * @param {number} dangerAreaData.longitude - 경도
+     * @param {number} dangerAreaData.width - 너비
+     * @param {number} dangerAreaData.height - 높이
+     * @param {string} dangerAreaData.name - 위험구역 이름
+     * @returns {Promise} 등록된 위험구역 정보
+     */
+    createRiskZone: async (dangerAreaData) => {
+        const url = `${API_CONFIG.gateway}/api/dashboard/danger-areas`;
+        return await apiRequest(url, {
+            method: 'POST',
+            body: JSON.stringify(dangerAreaData)
+        });
+    },
+
+    /**
+     * 위험구역 수정
+     * @param {number} dangerAreaId - 수정할 위험구역 ID
+     * @param {object} dangerAreaData - 수정할 위험구역 데이터
+     * @param {number} dangerAreaData.blueprintId - 도면 ID
+     * @param {number} dangerAreaData.latitude - 위도
+     * @param {number} dangerAreaData.longitude - 경도
+     * @param {number} dangerAreaData.width - 너비
+     * @param {number} dangerAreaData.height - 높이
+     * @param {string} dangerAreaData.name - 위험구역 이름
+     * @returns {Promise} 수정된 위험구역 정보
+     */
+    updateRiskZone: async (dangerAreaId, dangerAreaData) => {
+        const url = `${API_CONFIG.gateway}/api/dashboard/danger-areas/${dangerAreaId}`;
+        return await apiRequest(url, {
+            method: 'PUT',
+            body: JSON.stringify(dangerAreaData)
+        });
+    },
+
+    /**
+     * 위험구역 삭제
+     * @param {number} dangerAreaId - 삭제할 위험구역 ID
+     * @returns {Promise} 삭제 응답 데이터
+     */
+    deleteRiskZone: async (dangerAreaId) => {
+        const url = `${API_CONFIG.gateway}/api/dashboard/danger-areas/${dangerAreaId}`;
+        return await apiRequest(url, {
+            method: 'DELETE'
+        });
+    }
+};

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -441,15 +441,32 @@ export const blueprintAPI = {
      * @param {object} options
      * @param {number} options.page - 페이지 번호 (기본값: 0)
      * @param {number} options.size - 페이지당 개수 (기본값: 10)
+     * @param {string} [options.target] - 검색 대상 (예: "floor")
+     * @param {string} [options.keyword] - 검색 키워드 (예: "1")
      * @returns {Promise} 도면 목록 데이터
      */
-    getBlueprints: async ({page = 0, size = 10} = {}) => {
+    getBlueprints: async ({page = 0, size = 10, target = null, keyword = null} = {}) => {
         const queryParams = new URLSearchParams({
             page: page.toString(),
             size: size.toString(),
         });
 
+        if (target && keyword) {
+            queryParams.append('target', target);
+            queryParams.append('keyword', keyword);
+        }
+
         const url = `${API_CONFIG.gateway}/api/dashboard/blueprints?${queryParams.toString()}`;
+        return await apiRequest(url);
+    },
+
+    /**
+     * 단일 도면 조회
+     * @param {number} blueprintId - 도면 ID
+     * @returns {Promise} 도면 데이터
+     */
+    getBlueprint: async (blueprintId) => {
+        const url = `${API_CONFIG.gateway}/api/dashboard/blueprints/${blueprintId}`;
         return await apiRequest(url);
     },
 
@@ -480,6 +497,28 @@ export const blueprintAPI = {
      */
     getBlueprintImage(blueprintId) {
         return `${API_CONFIG.gateway}/api/dashboard/blueprints/${blueprintId}/image`;
+    },
+
+    /**
+     * 도면 이미지 Blob 데이터 조회 (인증 헤더 포함)
+     * @param {number} blueprintId - 도면 ID
+     * @returns {Promise<string>} Blob URL
+     */
+    getBlueprintImageBlob: async (blueprintId) => {
+        const url = `${API_CONFIG.gateway}/api/dashboard/blueprints/${blueprintId}/image`;
+        
+        const response = await fetch(url, {
+            headers: {
+                'Authorization': authUtils.getAuthHeader()
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`이미지 로드 실패: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        return URL.createObjectURL(blob);
     },
 
     /**

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Mail, Phone, MapPin, FileText, HelpCircle, Shield } from 'lucide-react';
 
 const Footer = () => {
     const footerStyle = {
@@ -19,69 +18,6 @@ const Footer = () => {
         boxSizing: 'border-box'
     };
 
-    const sectionStyle = {
-        flex: '1',
-        minWidth: '200px'
-    };
-
-    const titleStyle = {
-        fontSize: '16px',
-        fontWeight: '600',
-        color: '#1f2937',
-        marginBottom: '16px'
-    };
-
-    const companyTitleStyle = {
-        fontSize: '20px',
-        fontWeight: '700',
-        color: '#3b82f6',
-        marginBottom: '8px'
-    };
-
-    const descriptionStyle = {
-        fontSize: '14px',
-        color: '#6b7280',
-        lineHeight: '1.6',
-        marginBottom: '16px'
-    };
-
-    const contactItemStyle = {
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px',
-        marginBottom: '8px',
-        fontSize: '14px',
-        color: '#4b5563'
-    };
-
-    const linkStyle = {
-        display: 'block',
-        fontSize: '14px',
-        color: '#6b7280',
-        textDecoration: 'none',
-        marginBottom: '8px',
-        padding: '4px 0',
-        transition: 'color 0.2s',
-        cursor: 'pointer'
-    };
-
-    const bottomBarStyle = {
-        borderTop: '1px solid #e5e7eb',
-        marginTop: '32px',
-        paddingTop: '20px',
-        textAlign: 'center',
-        fontSize: '12px',
-        color: '#9ca3af'
-    };
-
-    const handleLinkHover = (e) => {
-        e.target.style.color = '#3b82f6';
-    };
-
-    const handleLinkLeave = (e) => {
-        e.target.style.color = '#6b7280';
-    };
-
     return (
         <footer style={footerStyle}>
             <div style={containerStyle}>
@@ -94,30 +30,51 @@ const Footer = () => {
 
                     {/* 가운데: 링크들 */}
                     <div style={{display: 'flex', alignItems: 'center', gap: '20px', fontSize: '14px'}}>
-                        <a 
-                            href="#" 
-                            style={{color: '#6b7280', textDecoration: 'none'}}
+                        <button 
+                            type="button"
+                            style={{
+                                color: '#6b7280', 
+                                textDecoration: 'none',
+                                background: 'none',
+                                border: 'none',
+                                cursor: 'pointer',
+                                fontSize: '14px'
+                            }}
                             onMouseEnter={(e) => e.target.style.color = '#374151'}
                             onMouseLeave={(e) => e.target.style.color = '#6b7280'}
                         >
                             가이드
-                        </a>
-                        <a 
-                            href="#" 
-                            style={{color: '#6b7280', textDecoration: 'none'}}
+                        </button>
+                        <button 
+                            type="button"
+                            style={{
+                                color: '#6b7280', 
+                                textDecoration: 'none',
+                                background: 'none',
+                                border: 'none',
+                                cursor: 'pointer',
+                                fontSize: '14px'
+                            }}
                             onMouseEnter={(e) => e.target.style.color = '#374151'}
                             onMouseLeave={(e) => e.target.style.color = '#6b7280'}
                         >
                             개인정보
-                        </a>
-                        <a 
-                            href="#" 
-                            style={{color: '#6b7280', textDecoration: 'none'}}
+                        </button>
+                        <button 
+                            type="button"
+                            style={{
+                                color: '#6b7280', 
+                                textDecoration: 'none',
+                                background: 'none',
+                                border: 'none',
+                                cursor: 'pointer',
+                                fontSize: '14px'
+                            }}
                             onMouseEnter={(e) => e.target.style.color = '#374151'}
                             onMouseLeave={(e) => e.target.style.color = '#6b7280'}
                         >
                             문의
-                        </a>
+                        </button>
                     </div>
 
                     {/* 오른쪽: 저작권 */}

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Mail, Phone, MapPin, FileText, HelpCircle, Shield } from 'lucide-react';
+
+const Footer = () => {
+    const footerStyle = {
+        backgroundColor: '#ffffff',
+        borderTop: '1px solid #e5e7eb',
+        padding: '16px 24px',
+        marginTop: 'auto',
+        width: '100%',
+        boxSizing: 'border-box',
+        overflow: 'hidden'
+    };
+
+    const containerStyle = {
+        width: '100%',
+        margin: '0 auto',
+        maxWidth: '1200px',
+        boxSizing: 'border-box'
+    };
+
+    const sectionStyle = {
+        flex: '1',
+        minWidth: '200px'
+    };
+
+    const titleStyle = {
+        fontSize: '16px',
+        fontWeight: '600',
+        color: '#1f2937',
+        marginBottom: '16px'
+    };
+
+    const companyTitleStyle = {
+        fontSize: '20px',
+        fontWeight: '700',
+        color: '#3b82f6',
+        marginBottom: '8px'
+    };
+
+    const descriptionStyle = {
+        fontSize: '14px',
+        color: '#6b7280',
+        lineHeight: '1.6',
+        marginBottom: '16px'
+    };
+
+    const contactItemStyle = {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        marginBottom: '8px',
+        fontSize: '14px',
+        color: '#4b5563'
+    };
+
+    const linkStyle = {
+        display: 'block',
+        fontSize: '14px',
+        color: '#6b7280',
+        textDecoration: 'none',
+        marginBottom: '8px',
+        padding: '4px 0',
+        transition: 'color 0.2s',
+        cursor: 'pointer'
+    };
+
+    const bottomBarStyle = {
+        borderTop: '1px solid #e5e7eb',
+        marginTop: '32px',
+        paddingTop: '20px',
+        textAlign: 'center',
+        fontSize: '12px',
+        color: '#9ca3af'
+    };
+
+    const handleLinkHover = (e) => {
+        e.target.style.color = '#3b82f6';
+    };
+
+    const handleLinkLeave = (e) => {
+        e.target.style.color = '#6b7280';
+    };
+
+    return (
+        <footer style={footerStyle}>
+            <div style={containerStyle}>
+                <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '16px'}}>
+                    {/* 왼쪽: 회사 정보 */}
+                    <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+                        <span style={{fontSize: '16px', fontWeight: '600', color: '#374151'}}>이룸</span>
+                        <span style={{fontSize: '14px', color: '#9ca3af'}}>건설 현장 안전 모니터링</span>
+                    </div>
+
+                    {/* 가운데: 링크들 */}
+                    <div style={{display: 'flex', alignItems: 'center', gap: '20px', fontSize: '14px'}}>
+                        <a 
+                            href="#" 
+                            style={{color: '#6b7280', textDecoration: 'none'}}
+                            onMouseEnter={(e) => e.target.style.color = '#374151'}
+                            onMouseLeave={(e) => e.target.style.color = '#6b7280'}
+                        >
+                            가이드
+                        </a>
+                        <a 
+                            href="#" 
+                            style={{color: '#6b7280', textDecoration: 'none'}}
+                            onMouseEnter={(e) => e.target.style.color = '#374151'}
+                            onMouseLeave={(e) => e.target.style.color = '#6b7280'}
+                        >
+                            개인정보
+                        </a>
+                        <a 
+                            href="#" 
+                            style={{color: '#6b7280', textDecoration: 'none'}}
+                            onMouseEnter={(e) => e.target.style.color = '#374151'}
+                            onMouseLeave={(e) => e.target.style.color = '#6b7280'}
+                        >
+                            문의
+                        </a>
+                    </div>
+
+                    {/* 오른쪽: 저작권 */}
+                    <div style={{fontSize: '13px', color: '#9ca3af'}}>
+                        © 2025 이룸. All rights reserved.
+                    </div>
+                </div>
+            </div>
+        </footer>
+    );
+};
+
+export default Footer;

--- a/frontend/src/pages/AdminLogin.js
+++ b/frontend/src/pages/AdminLogin.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import styles from '../styles/AdminLogin.module.css';
 import {userAPI} from '../api/api';
+import Footer from '../components/Footer';
 
 const AdminLogin = ({onLogin}) => {
     const navigate = useNavigate();
@@ -189,6 +190,7 @@ const AdminLogin = ({onLogin}) => {
                     </div>
                 </form>
             </div>
+            <Footer />
         </div>
     );
 };

--- a/frontend/src/pages/BlueprintPage.js
+++ b/frontend/src/pages/BlueprintPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styles from '../styles/Blueprint.module.css';
 import { blueprintAPI } from '../api/api';
 import { authUtils } from '../utils/auth';
@@ -42,7 +42,7 @@ const BlueprintPage = () => {
     const pageSize = 7;
 
     // 도면 목록 조회 함수
-    const fetchBlueprints = async (page = 0) => {
+    const fetchBlueprints = useCallback(async (page = 0) => {
         try {
             setLoading(true);
             setError(null);
@@ -69,11 +69,13 @@ const BlueprintPage = () => {
         } finally {
             setLoading(false);
         }
-    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pageSize]);
 
     // 컴포넌트 마운트 시 도면 목록 조회
     useEffect(() => {
         fetchBlueprints(0).catch(console.error);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // 컴포넌트 언마운트 시 blob URL 정리
@@ -632,13 +634,17 @@ const BlueprintPage = () => {
                                     <div className={styles.detailItem}>
                                         <span className={styles.detailLabel}>도면 URL:</span>
                                         <span className={styles.detailValue}>
-                                            <a
-                                                href={typeof imageBlob === 'string' ? imageBlob : '#'}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                도면 보기
-                                            </a>
+                                            {typeof imageBlob === 'string' ? (
+                                                <a
+                                                    href={imageBlob}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                >
+                                                    이미지 새창에서 보기
+                                                </a>
+                                            ) : (
+                                                <span>이미지 로딩 중...</span>
+                                            )}
                                         </span>
                                     </div>
                                 )}

--- a/frontend/src/pages/PrivacyConsentPage.js
+++ b/frontend/src/pages/PrivacyConsentPage.js
@@ -1,25 +1,77 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { userAPI } from '../api/api';
 import styles from '../styles/PrivacyConsent.module.css';
 
+/** 관리자 회원가입 동의서 설정 (관리자 전용) */
+const PRIVACY_CONFIG = {
+    companyName: '이룸',
+    serviceName: '건설 현장 안전 모니터링 시스템 (i-Room)',
+
+    // 관리자 회원가입용 수집항목
+    adminFields: {
+        required: ['이름', '이메일', '비밀번호', '휴대폰번호'],
+        optional: ['부서/직책']
+    },
+
+    // 관리자 동의서 목적(요약)
+    purposes: [
+        '관리자 계정 생성 및 본인확인, 로그인 인증',
+        '서비스 운영 및 고객지원',
+        '접속 보안 및 시스템 유지보수'
+    ],
+
+    // 관리자 보유기간(요약)
+    retentionPeriods: [
+        '관리자 계정: 회원 탈퇴 시까지 (탈퇴 시 즉시 파기)',
+        '관련 법령에 따른 별도 보존기간이 있는 경우 해당 기간 적용'
+    ],
+
+    // 법적 근거(요약)
+    legalBasis: ['개인정보보호법 제15조, 제17조 (정보주체 동의)'],
+
+
+    dpo: {
+        name: '개인정보보호책임자 김○○',
+        email: 'privacy@iroom.com',
+        phone: '02-1234-5678'
+    },
+
+    policyPath: '/privacy-policy',
+    tosPath: '/terms-of-service'
+};
+
 const PrivacyConsentPage = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const [agreed, setAgreed] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
 
-    // AdminSignUpPage에서 전달된 회원가입 데이터
+    // 분리 동의(필수 2개)
+    const [consent, setConsent] = useState({
+        use: false,      // [필수] 수집·이용 동의
+        tos: false       // [필수] 이용약관 동의
+    });
+    const requiredOk = consent.use && consent.tos;
+
     const signUpData = location.state?.signUpData;
 
-    const handleCancel = () => {
-        navigate('/admin/signUp');
-    };
+
+    const legalList = useMemo(
+        () => ({
+            adminRequired: PRIVACY_CONFIG.adminFields.required.join(', '),
+            adminOptional:
+                PRIVACY_CONFIG.adminFields.optional.length > 0
+                    ? PRIVACY_CONFIG.adminFields.optional.join(', ')
+                    : '해당 없음'
+        }),
+        []
+    );
+
+    const handleCancel = () => navigate('/admin/signup');
 
     const handleAgree = async () => {
-        if (!agreed) return;
+        if (!requiredOk) return;
 
-        // 회원가입 데이터가 없으면 회원가입 페이지로 돌아가기
         if (!signUpData) {
             alert('회원가입 정보가 없습니다. 다시 회원가입을 진행해주세요.');
             navigate('/admin/signup');
@@ -28,23 +80,15 @@ const PrivacyConsentPage = () => {
 
         try {
             setIsLoading(true);
-
-            // 회원가입 API 호출
             await userAPI.signUp(signUpData);
-
             alert('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
             navigate('/admin/login');
-
         } catch (error) {
             console.error('회원가입 실패:', error);
-            alert(error.message || '회원가입에 실패했습니다. 다시 시도해주세요.');
+            alert(error?.message || '회원가입에 실패했습니다. 다시 시도해주세요.');
         } finally {
             setIsLoading(false);
         }
-    };
-
-    const handleCheckboxChange = (e) => {
-        setAgreed(e.target.checked);
     };
 
     return (
@@ -52,71 +96,124 @@ const PrivacyConsentPage = () => {
             {/* 상단 바 */}
             <header className={styles.topBar}>
                 <span className={styles.circle} aria-hidden="true" />
-                <span className={styles.logoText}>이룸</span>
+                <span className={styles.logoText}>{PRIVACY_CONFIG.companyName}</span>
             </header>
 
             {/* 본문 */}
             <div className={styles.mainContent}>
                 <h1 className={styles.title}>관리자 회원가입</h1>
+                <p style={{textAlign: 'center', margin: '4px 0 0 0', color: '#666'}}>
+                    관리자 회원가입을 위해 아래 약관 및 개인정보 처리에 대한 동의가 필요합니다.
+                </p>
                 <hr className={styles.divider} />
 
+                {/* 1. 개인정보 수집·이용 동의 */}
                 <div className={styles.agreementBox}>
-                    <h2 className={styles.agreementTitle}>「개인정보 수집 및 이용 동의서」</h2>
-                    <p className={styles.agreementSubtitle}>
-                        회사는 서비스 제공을 위하여 다음과 같은 개인정보를 수집 및 이용합니다.
-                    </p>
-
+                    <h2 className={styles.agreementTitle}>1. 개인정보 수집·이용 동의 (필수)</h2>
                     <div className={styles.agreementContent}>
                         <div className={styles.agreementSection}>
-                            <h4>1. 수집 항목</h4>
-                            <p>- 필수정보: 이름, 이메일 주소, 비밀번호, 직무</p>
-                            <p>- 선택정보: 생년월일, 성별, 주소</p>
+                            <h4>수집 항목</h4>
+                            <p>- <strong>필수정보</strong>: {legalList.adminRequired}</p>
+                            <p>- <strong>선택정보</strong>: {legalList.adminOptional}</p>
                         </div>
-
+                        
                         <div className={styles.agreementSection}>
-                            <h4>2. 수집 및 이용 목적</h4>
-                            <p>- 회원 식별 및 관리</p>
-                            <p>- 서비스 이용에 따른 본인확인</p>
-                            <p>- 고객문의 및 불만 처리</p>
-                            <p>- 고지사항 전달</p>
+                            <h4>수집 및 이용 목적</h4>
+                            {PRIVACY_CONFIG.purposes.map((p, i) => (
+                                <p key={i}>- {p}</p>
+                            ))}
                         </div>
-
+                        
                         <div className={styles.agreementSection}>
-                            <h4>3. 보유 및 이용기간</h4>
-                            <p>- 회원 탈퇴 시 즉시 파기</p>
-                            <p>- 관련 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관</p>
+                            <h4>보유 및 이용기간</h4>
+                            {PRIVACY_CONFIG.retentionPeriods.map((r, i) => (
+                                <p key={i}>- {r}</p>
+                            ))}
                         </div>
-
+                        
                         <div className={styles.agreementSection}>
-                            <h4>4. 동의 거부 권리 및 불이익</h4>
-                            <p>- 이용자는 개인정보 수집 및 이용에 대한 동의를 거부할 수 있습니다.</p>
-                            <p>- 단, 필수 정보 제공을 거부할 경우 서비스 이용이 제한될 수 있습니다.</p>
+                            <h4>동의 거부 권리</h4>
+                            <p>- 개인정보 수집·이용에 대한 동의를 거부할 권리가 있으나, 동의 거부 시 회원가입이 제한됩니다.</p>
                         </div>
+                    </div>
+                    
+                    {/* 동의 체크박스 */}
+                    <div className={styles.checkboxContainer} style={{ marginTop: '16px', padding: '12px', backgroundColor: '#f8f9fa', borderRadius: '8px' }}>
+                        <label className={styles.checkboxLabel} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                            <input
+                                type="checkbox"
+                                checked={consent.use}
+                                onChange={e => setConsent(s => ({ ...s, use: e.target.checked }))}
+                                className={styles.checkbox}
+                            />
+                            <span>
+                                <strong>[필수] 개인정보 수집·이용에 동의합니다</strong>
+                            </span>
+                        </label>
                     </div>
                 </div>
 
-                <div className={styles.checkboxContainer}>
-                    <input
-                        type="checkbox"
-                        id="agreement"
-                        checked={agreed}
-                        onChange={handleCheckboxChange}
-                        className={styles.checkbox}
-                    />
-                    <label htmlFor="agreement" className={styles.checkboxLabel}>
-                        개인정보 수집 및 이용에 동의합니다
-                    </label>
+
+                {/* 2. 서비스 이용약관 동의 */}
+                <div className={styles.agreementBox}>
+                    <h2 className={styles.agreementTitle}>2. 서비스 이용약관 동의 (필수)</h2>
+                    <div className={styles.agreementContent}>
+                        <p>서비스 이용을 위한 기본 약관입니다.</p>
+                        <div className={styles.agreementSection}>
+                            <p>- 서비스 이용 시 준수해야 할 사항과 회사와 이용자의 권리·의무가 포함되어 있습니다.</p>
+                            <p>- 서비스 정책 변경, 계정 관리, 서비스 중단 등에 관한 내용이 포함됩니다.</p>
+                            {PRIVACY_CONFIG.tosPath && (
+                                <p>
+                                    ※ <a href={PRIVACY_CONFIG.tosPath} target="_blank" rel="noreferrer">이용약관 전문 보기</a>
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                    
+                    {/* 동의 체크박스 */}
+                    <div className={styles.checkboxContainer} style={{ marginTop: '16px', padding: '12px', backgroundColor: '#f8f9fa', borderRadius: '8px' }}>
+                        <label className={styles.checkboxLabel} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                            <input
+                                type="checkbox"
+                                checked={consent.tos}
+                                onChange={e => setConsent(s => ({ ...s, tos: e.target.checked }))}
+                                className={styles.checkbox}
+                            />
+                            <span>
+                                <strong>[필수] 서비스 이용약관에 동의합니다</strong>
+                            </span>
+                        </label>
+                    </div>
                 </div>
 
+
+                {/* 추가 안내사항 */}
+                <div className={styles.agreementBox}>
+                    <h2 className={styles.agreementTitle}>추가 안내사항</h2>
+                    <div className={styles.agreementContent}>
+                        <p>- <strong>개인정보보호 책임자</strong>: {PRIVACY_CONFIG.dpo.name}</p>
+                        <p>- <strong>연락처</strong>: {PRIVACY_CONFIG.dpo.email}, {PRIVACY_CONFIG.dpo.phone}</p>
+                        <p>- 개인정보 처리에 관한 불만이 있으시면 개인정보보호위원회(privacy.go.kr)에 신고하실 수 있습니다.</p>
+                        {PRIVACY_CONFIG.policyPath && (
+                            <p>
+                                ※ <a href={PRIVACY_CONFIG.policyPath} target="_blank" rel="noopener noreferrer">
+                                개인정보 처리방침 전문 보기
+                            </a>
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                {/* 버튼 */}
                 <div className={styles.buttonRow}>
-                    <button type="button" className={styles.grayBtn} onClick={handleCancel}>
+                    <button type="button" className={styles.grayBtn} onClick={handleCancel} disabled={isLoading}>
                         취소
                     </button>
                     <button
                         type="button"
-                        className={`${styles.blackBtn} ${!agreed || isLoading ? styles.disabled : ''}`}
+                        className={`${styles.blackBtn} ${!requiredOk || isLoading ? styles.disabled : ''}`}
                         onClick={handleAgree}
-                        disabled={!agreed || isLoading}
+                        disabled={!requiredOk || isLoading}
                     >
                         {isLoading ? '회원가입 중...' : '회원가입'}
                     </button>

--- a/frontend/src/pages/RiskZonePage.js
+++ b/frontend/src/pages/RiskZonePage.js
@@ -1,6 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styles from '../styles/RiskZone.module.css';
-// import { riskZoneAPI } from '../api/api'; // API 연동 시 사용
+import { riskZoneAPI, blueprintAPI } from '../api/api';
+
+/**
+ * 위험구역 설정 및 관리 페이지
+ * 
+ * TODO: 향후 구현 예정
+ * - GPS 좌표 매핑 시스템 구현
+ * - 실제 좌표 기반 위험구역 표시
+ */
 
 const RiskZonePage = () => {
     const canvasRef = useRef(null);
@@ -25,58 +33,161 @@ const RiskZonePage = () => {
     const [totalPages, setTotalPages] = useState(1);
 
     // 위험구역 목록 데이터
-    const [riskZones, setRiskZones] = useState([
-        {
-            id: 1,
-            floor: '1F',
-            name: '3구역 크레인 작업 구역',
-            location: 'X: 37.5721, Y: 126.9876',
-            width: '6.5 m',
-            height: '12 m'
-        },
-        {
-            id: 2,
-            floor: '2F',
-            name: '1구역 전기함',
-            location: 'X: 37.5719, Y: 126.9868',
-            width: '6.5 m',
-            height: '12 m'
-        },
-        {
-            id: 3,
-            floor: '3F',
-            name: '2구역 계단 작업 구역',
-            location: 'X: 37.5705, Y: 126.9880',
-            width: '3.8 m',
-            height: '2.2 m'
-        }
-    ]);
+    const [riskZones, setRiskZones] = useState([]);
 
     // 캔버스에 그려진 위험구역들
     const [canvasZones, setCanvasZones] = useState([]);
 
-    // 컴포넌트 마운트 시 데이터 로드
+    // 도면 관련 상태
+    const [currentBlueprint, setCurrentBlueprint] = useState(null);
+    const [blueprintImage, setBlueprintImage] = useState(null);
+
+    // 수정 모달 상태
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [editingZone, setEditingZone] = useState(null);
+    const [editFormData, setEditFormData] = useState({
+        floor: 1,
+        latitude: '',
+        longitude: '',
+        width: '',
+        height: '',
+        name: ''
+    });
+    const [availableBlueprints, setAvailableBlueprints] = useState([]);
+
+    // 컴포넌트 마운트 시 위험구역 목록과 도면 목록 조회
     useEffect(() => {
         fetchRiskZones();
-    }, [currentPage, selectedFloor]);
+        fetchAvailableBlueprints();
+    }, [currentPage]);
+
+    // 초기 로드 + 층 변경 시 도면 조회
+    useEffect(() => {
+        fetchBlueprint();
+    }, [selectedFloor]);
+
+    // 컴포넌트 언마운트 시 blob URL 정리
+    useEffect(() => {
+        return () => {
+            if (blueprintImage && blueprintImage.startsWith('blob:')) {
+                URL.revokeObjectURL(blueprintImage);
+            }
+        };
+    }, [blueprintImage]);
 
     // 위험구역 데이터 조회
     const fetchRiskZones = async () => {
         try {
-            // API 호출 로직
-            // const response = await riskZoneAPI.getRiskZones({
-            //     page: currentPage,
-            //     size: pageSize,
-            //     floor: selectedFloor
-            // });
-            // setRiskZones(response.data.content || []);
-            // setTotalPages(response.data.totalPages || 1);
+            const response = await riskZoneAPI.getRiskZones({
+                page: currentPage,
+                size: pageSize
+            });
 
-            // 임시 데이터 필터링
-            const filteredZones = riskZones.filter(zone => zone.floor === selectedFloor);
-            setTotalPages(Math.ceil(filteredZones.length / pageSize));
+            const data = response.data || response;
+            const zones = data.content || [];
+            
+            // Blueprint 정보 조회해서 floor 매핑
+            const formattedZones = await Promise.all(
+                zones.map(async (zone) => {
+                    try {
+                        // blueprintId로 Blueprint 정보 조회
+                        const blueprintResponse = await blueprintAPI.getBlueprint(zone.blueprintId);
+                        const blueprint = blueprintResponse.data || blueprintResponse;
+                        
+                        return {
+                            id: zone.id,
+                            floor: `${blueprint.floor}F`,
+                            name: zone.name || `위험구역 ${zone.id}`,
+                            latitude: zone.latitude,
+                            longitude: zone.longitude,
+                            width: `${zone.width} m`,
+                            height: `${zone.height} m`,
+                            // 원본 데이터도 보관
+                            blueprintId: zone.blueprintId,
+                            originalWidth: zone.width,
+                            originalHeight: zone.height
+                        };
+                    } catch (error) {
+                        console.error(`Blueprint ${zone.blueprintId} 조회 실패:`, error);
+                        // Blueprint 조회 실패 시 기본값 사용
+                        return {
+                            id: zone.id,
+                            floor: `${zone.blueprintId}F`, // fallback
+                            name: zone.name || `위험구역 ${zone.id}`,
+                            latitude: zone.latitude,
+                            longitude: zone.longitude,
+                            width: `${zone.width} m`,
+                            height: `${zone.height} m`,
+                            blueprintId: zone.blueprintId,
+                            originalWidth: zone.width,
+                            originalHeight: zone.height
+                        };
+                    }
+                })
+            );
+            
+            setRiskZones(formattedZones);
+            setTotalPages(data.totalPages || 1);
+
         } catch (error) {
             console.error('위험구역 데이터 조회 실패:', error);
+            setRiskZones([]);
+            setTotalPages(1);
+        }
+    };
+
+    // 사용 가능한 도면 목록 조회 (수정 모달용)
+    const fetchAvailableBlueprints = async () => {
+        try {
+            const response = await blueprintAPI.getBlueprints({
+                page: 0,
+                size: 50 // 충분히 많이 가져오기
+            });
+
+            const data = response.data || response;
+            setAvailableBlueprints(data.content || []);
+        } catch (error) {
+            console.error('도면 목록 조회 실패:', error);
+            setAvailableBlueprints([]);
+        }
+    };
+
+    // 도면 데이터 조회
+    const fetchBlueprint = async () => {
+        try {
+            const floorNumber = parseInt(selectedFloor.replace('F', '')); // "1F" -> 1
+            const response = await blueprintAPI.getBlueprints({
+                page: 0,
+                size: 1,
+                target: 'floor',
+                keyword: floorNumber.toString()
+            });
+
+            const data = response.data || response;
+            
+            if (data.content && data.content.length > 0) {
+                const blueprint = data.content[0];
+                setCurrentBlueprint(blueprint);
+                console.log(`${selectedFloor} 도면 로드됨 - ID: ${blueprint.id}, Floor: ${blueprint.floor}`);
+                
+                // 도면 이미지 Blob URL 생성 (인증 헤더 포함)
+                try {
+                    const blobUrl = await blueprintAPI.getBlueprintImageBlob(blueprint.id);
+                    setBlueprintImage(blobUrl);
+                } catch (imageError) {
+                    console.error('도면 이미지 로드 실패:', imageError);
+                    setBlueprintImage(null);
+                }
+            } else {
+                // 해당 층의 도면이 없는 경우
+                console.warn(`${selectedFloor} 층의 도면을 찾을 수 없습니다.`);
+                setCurrentBlueprint(null);
+                setBlueprintImage(null);
+            }
+        } catch (error) {
+            console.error('도면 데이터 조회 실패:', error);
+            setCurrentBlueprint(null);
+            setBlueprintImage(null);
         }
     };
 
@@ -120,13 +231,13 @@ const RiskZonePage = () => {
             setCanvasZones(prev => [...prev, newZone]);
             setSelectedZone(newZone);
 
-            // 위치 정보 업데이트
+            // 위치 정보 업데이트 (GPS 좌표 매핑 구현 후 수정 필요)
             setLocationInfo({
                 x: newZone.x.toFixed(2),
                 y: newZone.y.toFixed(2),
                 name: '',
-                width: (newZone.width * 0.1).toFixed(1), // 임시 스케일 변환
-                height: (newZone.height * 0.1).toFixed(1)
+                width: newZone.width.toFixed(1),
+                height: newZone.height.toFixed(1)
             });
         }
 
@@ -149,45 +260,45 @@ const RiskZonePage = () => {
             x: zone.x.toFixed(2),
             y: zone.y.toFixed(2),
             name: zone.name || '',
-            width: (zone.width * 0.1).toFixed(1),
-            height: (zone.height * 0.1).toFixed(1)
+            width: zone.width.toFixed(1),
+            height: zone.height.toFixed(1)
         });
     };
 
-    // 위치 정보 저장
+    // 위치 정보 저장 (위험구역 등록)
     const handleSaveLocation = async () => {
-        if (!selectedZone || !locationInfo.name.trim()) {
-            alert('구역을 선택하고 이름을 입력해주세요.');
+        if (!selectedZone) {
+            alert('구역을 선택해주세요.');
+            return;
+        }
+
+        if (!currentBlueprint || !currentBlueprint.id) {
+            alert('도면 정보가 없습니다. 층수를 선택해주세요.');
             return;
         }
 
         try {
-            // API 호출 로직
-            // const zoneData = {
-            //     floor: selectedFloor,
-            //     name: locationInfo.name,
-            //     x: parseFloat(locationInfo.x),
-            //     y: parseFloat(locationInfo.y),
-            //     width: parseFloat(locationInfo.width),
-            //     height: parseFloat(locationInfo.height)
-            // };
-            // await riskZoneAPI.createRiskZone(zoneData);
+            console.log('locationInfo:', locationInfo);
+            console.log('locationInfo.name:', locationInfo.name);
+            
+            // 캔버스 좌표를 실제 GPS 좌표로 변환 (여기서는 임시로 그대로 사용)
+            const riskZoneData = {
+                blueprintId: currentBlueprint.id,
+                latitude: parseFloat(locationInfo.x) || selectedZone.x,
+                longitude: parseFloat(locationInfo.y) || selectedZone.y,
+                width: parseFloat(locationInfo.width) || selectedZone.width,
+                height: parseFloat(locationInfo.height) || selectedZone.height,
+                name: locationInfo.name.trim() || `위험구역 ${Date.now()}`
+            };
 
-            alert('위험구역이 저장되었습니다.');
-
-            // 캔버스 위험구역에 이름 추가
-            setCanvasZones(prev =>
-                prev.map(zone =>
-                    zone.id === selectedZone.id
-                        ? { ...zone, name: locationInfo.name }
-                        : zone
-                )
-            );
-
-            // 목록 새로고침
-            await fetchRiskZones();
-
-            // 폼 초기화
+            console.log('위험구역 등록 데이터:', riskZoneData);
+            const response = await riskZoneAPI.createRiskZone(riskZoneData);
+            console.log('위험구역 등록 완료:', response);
+            
+            alert('위험구역이 성공적으로 등록되었습니다.');
+            
+            // 캔버스에서 임시 구역 제거
+            setCanvasZones(prev => prev.filter(zone => zone.id !== selectedZone.id));
             setSelectedZone(null);
             setLocationInfo({
                 x: '',
@@ -196,17 +307,103 @@ const RiskZonePage = () => {
                 width: '',
                 height: ''
             });
+            
+            // 목록 새로고침
+            await fetchRiskZones();
 
         } catch (error) {
             console.error('위험구역 저장 실패:', error);
-            alert('저장에 실패했습니다.');
+            alert(`저장에 실패했습니다: ${error.message}`);
         }
     };
 
-    // 위험구역 수정
-    const handleEdit = (zone) => {
-        console.log('위험구역 수정:', zone);
-        // 수정 모달 또는 폼 표시
+    // 위험구역 수정 모달 열기
+    const handleEdit = async (zone) => {
+        setEditingZone(zone);
+        
+        // blueprintId로 해당 도면 정보 조회해서 floor 가져오기
+        try {
+            const blueprintResponse = await blueprintAPI.getBlueprint(zone.blueprintId);
+            const blueprint = blueprintResponse.data || blueprintResponse;
+            
+            setEditFormData({
+                floor: blueprint.floor || 1,
+                latitude: zone.latitude || 0,
+                longitude: zone.longitude || 0,
+                width: zone.originalWidth || parseFloat(zone.width) || 0,
+                height: zone.originalHeight || parseFloat(zone.height) || 0,
+                name: zone.name || ''
+            });
+        } catch (error) {
+            console.error('도면 정보 조회 실패:', error);
+            setEditFormData({
+                floor: 1,
+                latitude: zone.latitude || 0,
+                longitude: zone.longitude || 0,
+                width: zone.originalWidth || parseFloat(zone.width) || 0,
+                height: zone.originalHeight || parseFloat(zone.height) || 0,
+                name: zone.name || ''
+            });
+        }
+        
+        setIsEditModalOpen(true);
+    };
+
+    // 수정 모달 닫기
+    const handleCloseEditModal = () => {
+        setIsEditModalOpen(false);
+        setEditingZone(null);
+        setEditFormData({
+            floor: 1,
+            latitude: '',
+            longitude: '',
+            width: '',
+            height: '',
+            name: ''
+        });
+    };
+
+    // 수정 폼 데이터 변경
+    const handleEditFormChange = (field, value) => {
+        setEditFormData(prev => ({
+            ...prev,
+            [field]: value
+        }));
+    };
+
+    // 위험구역 수정 저장
+    const handleSaveEdit = async () => {
+        if (!editingZone) return;
+
+        try {
+            // 선택된 층수에 해당하는 blueprintId 찾기
+            const selectedBlueprint = availableBlueprints.find(bp => bp.floor === editFormData.floor);
+            if (!selectedBlueprint) {
+                alert(`${editFormData.floor}층에 해당하는 도면을 찾을 수 없습니다.`);
+                return;
+            }
+
+            const updateData = {
+                blueprintId: selectedBlueprint.id,
+                latitude: parseFloat(editFormData.latitude),
+                longitude: parseFloat(editFormData.longitude),
+                width: parseFloat(editFormData.width),
+                height: parseFloat(editFormData.height),
+                name: editFormData.name.trim() || `위험구역 ${editingZone.id}`
+            };
+
+            await riskZoneAPI.updateRiskZone(editingZone.id, updateData);
+            
+            alert('위험구역이 성공적으로 수정되었습니다.');
+            handleCloseEditModal();
+            
+            // 목록 새로고침
+            await fetchRiskZones();
+            
+        } catch (error) {
+            console.error('위험구역 수정 실패:', error);
+            alert(`수정에 실패했습니다: ${error.message}`);
+        }
     };
 
     // 위험구역 삭제
@@ -216,14 +413,14 @@ const RiskZonePage = () => {
         }
 
         try {
-            // API 호출 로직
-            // await riskZoneAPI.deleteRiskZone(zoneId);
-
-            setRiskZones(prev => prev.filter(zone => zone.id !== zoneId));
-            alert('위험구역이 삭제되었습니다.');
+            await riskZoneAPI.deleteRiskZone(zoneId);
+            alert('위험구역이 성공적으로 삭제되었습니다.');
+            
+            // 목록 새로고침
+            await fetchRiskZones();
         } catch (error) {
             console.error('위험구역 삭제 실패:', error);
-            alert('삭제에 실패했습니다.');
+            alert(`삭제에 실패했습니다: ${error.message}`);
         }
     };
 
@@ -239,10 +436,8 @@ const RiskZonePage = () => {
         };
     };
 
-    // 현재 페이지 데이터
-    const currentZones = riskZones
-        .filter(zone => zone.floor === selectedFloor)
-        .slice(currentPage * pageSize, (currentPage + 1) * pageSize);
+    // 현재 페이지 데이터 (API에서 이미 페이지네이션 적용됨)
+    const currentZones = riskZones;
 
     return (
         <div className={styles.page}>
@@ -277,7 +472,22 @@ const RiskZonePage = () => {
                         onMouseMove={handleMouseMove}
                         onMouseUp={handleMouseUp}
                     >
-                        <div className={styles.canvas}>
+                        <div 
+                            className={styles.canvas}
+                            style={{
+                                backgroundImage: blueprintImage ? `url(${blueprintImage})` : 'none',
+                                backgroundSize: 'contain',
+                                backgroundRepeat: 'no-repeat',
+                                backgroundPosition: 'center'
+                            }}
+                        >
+                            {/* 도면이 없는 경우 안내 메시지 */}
+                            {!blueprintImage && (
+                                <div className={styles.noBlueprintMessage}>
+                                    {selectedFloor} 층의 도면이 없습니다
+                                </div>
+                            )}
+                            
                             {/* 기존 위험구역들 */}
                             {canvasZones.map(zone => (
                                 <div
@@ -311,12 +521,15 @@ const RiskZonePage = () => {
 
                     <div className={styles.coordinateInfo}>
                         <p className={styles.coordinateText}>
-                            X: {locationInfo.x || '50.35'}, Y: {locationInfo.y || '64.63'}
+                            위치: {locationInfo.x ? `X: ${locationInfo.x}, Y: ${locationInfo.y}` : '영역을 선택해주세요'}
+                        </p>
+                        <p className={styles.coordinateText}>
+                            층수: {selectedFloor} {currentBlueprint ? '' : '(도면 없음)'}
                         </p>
                     </div>
 
                     <div className={styles.formGroup}>
-                        <label className={styles.formLabel}>Name</label>
+                        <label className={styles.formLabel}>이름</label>
                         <input
                             type="text"
                             className={styles.formInput}
@@ -327,9 +540,10 @@ const RiskZonePage = () => {
                     </div>
 
                     <div className={styles.formGroup}>
-                        <label className={styles.formLabel}>Width</label>
+                        <label className={styles.formLabel}>너비 (Width)</label>
                         <input
-                            type="text"
+                            type="number"
+                            step="0.1"
                             className={styles.formInput}
                             value={locationInfo.width}
                             onChange={(e) => setLocationInfo(prev => ({ ...prev, width: e.target.value }))}
@@ -339,9 +553,10 @@ const RiskZonePage = () => {
                     </div>
 
                     <div className={styles.formGroup}>
-                        <label className={styles.formLabel}>Height</label>
+                        <label className={styles.formLabel}>높이 (Height)</label>
                         <input
-                            type="text"
+                            type="number"
+                            step="0.1"
                             className={styles.formInput}
                             value={locationInfo.height}
                             onChange={(e) => setLocationInfo(prev => ({ ...prev, height: e.target.value }))}
@@ -360,9 +575,9 @@ const RiskZonePage = () => {
                         <button
                             className={styles.saveLocationBtn}
                             onClick={handleSaveLocation}
-                            disabled={!selectedZone || !locationInfo.name.trim()}
+                            disabled={!selectedZone}
                         >
-                            위험구역 추가등록
+                            위험구역 등록
                         </button>
                     </div>
                 </div>
@@ -377,7 +592,8 @@ const RiskZonePage = () => {
                     <tr>
                         <th>Floor</th>
                         <th>Name</th>
-                        <th>Location</th>
+                        <th>Latitude</th>
+                        <th>Longitude</th>
                         <th>Width</th>
                         <th>Height</th>
                         <th>Button</th>
@@ -389,7 +605,8 @@ const RiskZonePage = () => {
                             <tr key={zone.id}>
                                 <td data-label="Floor">{zone.floor}</td>
                                 <td data-label="Name">{zone.name}</td>
-                                <td data-label="Location">{zone.location}</td>
+                                <td data-label="Latitude">{zone.latitude}</td>
+                                <td data-label="Longitude">{zone.longitude}</td>
                                 <td data-label="Width">{zone.width}</td>
                                 <td data-label="Height">{zone.height}</td>
                                 <td data-label="Button">
@@ -412,7 +629,7 @@ const RiskZonePage = () => {
                         ))
                     ) : (
                         <tr>
-                            <td colSpan="6" className={styles.emptyState}>
+                            <td colSpan="7" className={styles.emptyState}>
                                 등록된 위험구역이 없습니다.
                             </td>
                         </tr>
@@ -451,6 +668,114 @@ const RiskZonePage = () => {
                     </div>
                 )}
             </section>
+
+            {/* 수정 모달 */}
+            {isEditModalOpen && (
+                <div className={styles.modalOverlay}>
+                    <div className={styles.modal}>
+                        <div className={styles.modalHeader}>
+                            <h3 className={styles.modalTitle}>위험구역 수정</h3>
+                            <button 
+                                className={styles.modalCloseBtn}
+                                onClick={handleCloseEditModal}
+                            >
+                                ×
+                            </button>
+                        </div>
+                        
+                        <div className={styles.modalBody}>
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>층수</label>
+                                <select
+                                    className={styles.formInput}
+                                    value={editFormData.floor}
+                                    onChange={(e) => handleEditFormChange('floor', parseInt(e.target.value))}
+                                >
+                                    {availableBlueprints.map(blueprint => (
+                                        <option key={blueprint.id} value={blueprint.floor}>
+                                            {blueprint.floor}층
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>이름</label>
+                                <input
+                                    type="text"
+                                    className={styles.formInput}
+                                    value={editFormData.name}
+                                    onChange={(e) => handleEditFormChange('name', e.target.value)}
+                                    placeholder="위험구역 이름을 입력하세요"
+                                />
+                            </div>
+
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>위도 (Latitude)</label>
+                                <input
+                                    type="number"
+                                    step="0.0001"
+                                    className={styles.formInput}
+                                    value={editFormData.latitude}
+                                    onChange={(e) => handleEditFormChange('latitude', e.target.value)}
+                                    placeholder="위도를 입력하세요"
+                                />
+                            </div>
+
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>경도 (Longitude)</label>
+                                <input
+                                    type="number"
+                                    step="0.0001"
+                                    className={styles.formInput}
+                                    value={editFormData.longitude}
+                                    onChange={(e) => handleEditFormChange('longitude', e.target.value)}
+                                    placeholder="경도를 입력하세요"
+                                />
+                            </div>
+
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>너비 (Width)</label>
+                                <input
+                                    type="number"
+                                    step="0.1"
+                                    className={styles.formInput}
+                                    value={editFormData.width}
+                                    onChange={(e) => handleEditFormChange('width', e.target.value)}
+                                    placeholder="너비를 입력하세요"
+                                />
+                            </div>
+
+                            <div className={styles.formGroup}>
+                                <label className={styles.formLabel}>높이 (Height)</label>
+                                <input
+                                    type="number"
+                                    step="0.1"
+                                    className={styles.formInput}
+                                    value={editFormData.height}
+                                    onChange={(e) => handleEditFormChange('height', e.target.value)}
+                                    placeholder="높이를 입력하세요"
+                                />
+                            </div>
+                        </div>
+
+                        <div className={styles.modalFooter}>
+                            <button 
+                                className={styles.modalCancelBtn}
+                                onClick={handleCloseEditModal}
+                            >
+                                취소
+                            </button>
+                            <button 
+                                className={styles.modalSaveBtn}
+                                onClick={handleSaveEdit}
+                            >
+                                수정 완료
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/pages/WorkerDetailPage.js
+++ b/frontend/src/pages/WorkerDetailPage.js
@@ -406,6 +406,12 @@ const WorkerDetailPage = () => {
                         </div>
                     ) : (() => {
                         const { enterDate, outDate } = attendance;
+                        
+                        // 오늘 날짜 확인
+                        const today = new Date().toDateString();
+                        const isEnterToday = enterDate && new Date(enterDate).toDateString() === today;
+                        const isOutToday = outDate && new Date(outDate).toDateString() === today;
+                        
                         return (
                             <>
                                 <div className={styles.statusItem}>
@@ -431,8 +437,8 @@ const WorkerDetailPage = () => {
                                                 <span className={styles.statusTime}>-</span>
                                             )}
                                         </div>
-                                        <span className={enterDate ? styles.attendanceBadge : styles.workingBadge}>
-                                            {enterDate ? '출근 완료' : '미출근'}
+                                        <span className={isEnterToday ? styles.attendanceBadge : styles.workingBadge}>
+                                            {isEnterToday ? '출근 완료' : '미출근'}
                                         </span>
                                     </div>
                                 </div>
@@ -460,8 +466,8 @@ const WorkerDetailPage = () => {
                                                 <span className={styles.statusTime}>-</span>
                                             )}
                                         </div>
-                                        <span className={outDate ? styles.attendanceBadge : styles.workingBadge}>
-                                            {outDate ? '퇴근 완료' : '근무중'}
+                                        <span className={isOutToday ? styles.attendanceBadge : (isEnterToday ? styles.workingBadge : styles.workingBadge)}>
+                                            {isOutToday ? '퇴근 완료' : (isEnterToday ? '근무중' : '미출근')}
                                         </span>
                                     </div>
                                 </div>

--- a/frontend/src/styles/Blueprint.module.css
+++ b/frontend/src/styles/Blueprint.module.css
@@ -1,12 +1,14 @@
 /* 전체 페이지 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 페이지 헤더 */

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -1,12 +1,14 @@
 /* 전체 페이지 - 기존 스타일과 통일 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 페이지 헤더 - 기존과 동일 */
@@ -24,9 +26,16 @@
 /* 상단 섹션 - 종합 안전 점수 + 변동 추이 */
 .topSection {
     display: grid;
-    grid-template-columns: 400px 1fr;
-    gap: 32px;
+    grid-template-columns: minmax(300px, 400px) 1fr;
+    gap: 24px;
     margin-bottom: 32px;
+}
+
+@media (max-width: 768px) {
+    .topSection {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
 }
 
 /* 종합 안전 점수 카드 */

--- a/frontend/src/styles/Monitoring.module.css
+++ b/frontend/src/styles/Monitoring.module.css
@@ -1,12 +1,15 @@
 /* 전체 페이지 - 기존 스타일과 통일 */
 .page {
-    padding: 50px;
+    padding: 24px;
+    padding-bottom: 80px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 페이지 헤더 - 기존과 동일 */

--- a/frontend/src/styles/PrivacyConsent.module.css
+++ b/frontend/src/styles/PrivacyConsent.module.css
@@ -48,6 +48,14 @@
     gap: 32px;
 }
 
+/* 작은 설명 텍스트 */
+.smallNote {
+    font-size: 11px;
+    color: #6b7280;
+    margin-top: 4px;
+    line-height: 1.4;
+}
+
 /* 제목 */
 .title {
     font-size: 32px;
@@ -61,7 +69,7 @@
 
 /* 구분선 */
 .divider {
-    margin: 16px 0 32px 0;
+    margin: 4px 0 24px 0;
     width: 198px;
     border: none;
     border-top: 1.5px solid #a1a1aa;
@@ -121,8 +129,8 @@
 .agreementSection p {
     font-size: 13px;
     color: #4b5563;
-    margin: 4px 0;
-    line-height: 1.5;
+    margin: 2px 0;
+    line-height: 1.4;
 }
 
 /* 체크박스 영역 */

--- a/frontend/src/styles/Report.module.css
+++ b/frontend/src/styles/Report.module.css
@@ -1,11 +1,13 @@
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 .pageHeader {

--- a/frontend/src/styles/RiskZone.module.css
+++ b/frontend/src/styles/RiskZone.module.css
@@ -130,6 +130,22 @@
     pointer-events: none;
 }
 
+/* 도면 없음 메시지 */
+.noBlueprintMessage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #6B7280;
+    font-size: 16px;
+    font-weight: 500;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 12px 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
 /* 우측: 선택된 위치 정보 패널 */
 .locationPanel {
     background: #fff;
@@ -192,6 +208,14 @@
     background-color: #F9FAFB;
     color: #6B7280;
     cursor: not-allowed;
+}
+
+/* Select 요소 스타일 */
+select.formInput {
+    appearance: none;
+    background: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e") no-repeat right 8px center / 16px;
+    padding-right: 32px;
+    cursor: pointer;
 }
 
 .buttonGroup {
@@ -375,6 +399,111 @@
     text-align: center;
     color: #9CA3AF;
     font-style: italic;
+}
+
+/* 모달 스타일 */
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    width: 90%;
+    max-width: 500px;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 24px 0 24px;
+    border-bottom: 1px solid #E5E7EB;
+    margin-bottom: 24px;
+}
+
+.modalTitle {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.modalCloseBtn {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: #6B7280;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+}
+
+.modalCloseBtn:hover {
+    background-color: #F3F4F6;
+    color: #374151;
+}
+
+.modalBody {
+    padding: 0 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.modalFooter {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 24px;
+    border-top: 1px solid #E5E7EB;
+    margin-top: 24px;
+}
+
+.modalCancelBtn {
+    padding: 10px 20px;
+    border: 1px solid #D1D5DB;
+    background: white;
+    color: #374151;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.modalCancelBtn:hover {
+    background-color: #F9FAFB;
+    border-color: #9CA3AF;
+}
+
+.modalSaveBtn {
+    padding: 10px 20px;
+    border: none;
+    background: #3B82F6;
+    color: white;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.modalSaveBtn:hover {
+    background: #2563EB;
 }
 
 /* 반응형 디자인 */

--- a/frontend/src/styles/RiskZone.module.css
+++ b/frontend/src/styles/RiskZone.module.css
@@ -1,12 +1,14 @@
 /* 전체 페이지 - 기존 스타일과 통일 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 페이지 헤더 - 기존과 동일 */

--- a/frontend/src/styles/Settings.module.css
+++ b/frontend/src/styles/Settings.module.css
@@ -1,12 +1,37 @@
 /* 전체 페이지 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
+}
+
+/* 유효성 검증 스타일 */
+.passwordInput.error {
+    border-color: #ef4444;
+    background-color: #fef2f2;
+}
+
+.passwordInput.success {
+    border-color: #10b981;
+    background-color: #f0fdf4;
+}
+
+.successMessage {
+    font-size: 12px;
+    color: #10b981;
+    margin-top: 4px;
+}
+
+.errorMessage {
+    font-size: 12px;
+    color: #ef4444;
+    margin-top: 4px;
 }
 
 /* 페이지 헤더 */

--- a/frontend/src/styles/WorkerDetail.module.css
+++ b/frontend/src/styles/WorkerDetail.module.css
@@ -1,6 +1,6 @@
 /* 전체 페이지 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: calc(100vh - 60px);
     display: flex;
@@ -8,6 +8,7 @@
     gap: 32px;
     width: 100%;
     box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 로딩 및 에러 상태 */

--- a/frontend/src/styles/WorkerManagement.module.css
+++ b/frontend/src/styles/WorkerManagement.module.css
@@ -1,12 +1,14 @@
 /* 전체 페이지 */
 .page {
-    padding: 50px;
+    padding: 24px;
     background-color: #FAFBFF;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     gap: 32px;
     width: 100%;
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 /* 페이지 헤더 */


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---

## 변경 사항 
> 관리자 설정 페이지 완료
- 관리자 설정 페이지에 관리자 권한 변경 및 삭제 기능 추가
- 관리자 설정 페이지 비밀번호 변경 시 유효성 검사(특수문자 포함, 8~16자 제한) 로직 추가
- 근로자 상세 페이지 출퇴근 상태를 당일 기준으로 표시하도록 수정
- 로그인 페이지에 Footer 추가 (Footer 내 링크 클릭 시 현재는 동작 없음, 추후 개선 예정)
- 위험구역 페이지 조회 API 백엔드 연동
- 도면 전체 조회 API에 target 및 keyword 파라미터 추가하여 층별 도면 조회 지원
- 도면 단일 조회 API 추가
- 위험구역 반환 형식을 apiResponse 형식으로 변경
- 위험구역에 name 필드 추가
- 개인정보 동의 페이지 문구 수정
---
## 테스트 결과
<img width="2503" height="1390" alt="image" src="https://github.com/user-attachments/assets/9ae4515e-426a-4694-ac94-dff817ef39ea" />

<img width="2107" height="1397" alt="image" src="https://github.com/user-attachments/assets/6fe4c905-9fe0-4040-ab66-3d668cb6264b" />

---
## TODO
1. 관리자 페이지 알람 WebSocket 구현
2. 백엔드 도면 API에 각 꼭짓점 위·경도 정보 포함하도록 수정
3. 2번 수정사항에 맞춰 위험구역 프론트엔드 리팩토링