### PR TITLE
feat: 관리자 알림 구현 및 도면 꼭짓점 정보 포함하도록 구현

### DIFF
--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/dto/request/BlueprintRequest.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/dto/request/BlueprintRequest.java
@@ -1,9 +1,15 @@
 package com.iroom.dashboard.blueprint.dto.request;
 
 public record BlueprintRequest(
+	String name,
 	String blueprintUrl,
 	Integer floor,
 	Double width,
-	Double height
+	Double height,
+	GeoPointDto topLeft,
+	GeoPointDto topRight,
+	GeoPointDto bottomRight,
+	GeoPointDto bottomLeft
 ) {
+	public record GeoPointDto(Double lat, Double lon) {}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/dto/response/BlueprintResponse.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/dto/response/BlueprintResponse.java
@@ -1,22 +1,32 @@
 package com.iroom.dashboard.blueprint.dto.response;
 
+import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest;
 import com.iroom.dashboard.blueprint.entity.Blueprint;
 
 public record BlueprintResponse(
 	Long id,
+	String name,
 	String blueprintUrl,
 	Integer floor,
 	Double width,
-	Double height
+	Double height,
+	BlueprintRequest.GeoPointDto topLeft,
+	BlueprintRequest.GeoPointDto topRight,
+	BlueprintRequest.GeoPointDto bottomRight,
+	BlueprintRequest.GeoPointDto bottomLeft
 ) {
-	// 엔티티 -> DTO로 변환하는 생성자
-	public BlueprintResponse(Blueprint blueprint) {
+	public BlueprintResponse(Blueprint b) {
 		this(
-			blueprint.getId(),
-			blueprint.getBlueprintUrl(),
-			blueprint.getFloor(),
-			blueprint.getWidth(),
-			blueprint.getHeight()
+			b.getId(),
+			b.getName(),
+			b.getBlueprintUrl(),
+			b.getFloor(),
+			b.getWidth(),
+			b.getHeight(),
+			new BlueprintRequest.GeoPointDto(b.getTopLeft().getLat(), b.getTopLeft().getLon()),
+			new BlueprintRequest.GeoPointDto(b.getTopRight().getLat(), b.getTopRight().getLon()),
+			new BlueprintRequest.GeoPointDto(b.getBottomRight().getLat(), b.getBottomRight().getLon()),
+			new BlueprintRequest.GeoPointDto(b.getBottomLeft().getLat(), b.getBottomLeft().getLon())
 		);
 	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/entity/Blueprint.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/entity/Blueprint.java
@@ -13,6 +13,9 @@ public class Blueprint {
 	private Long id;
 
 	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
 	private String blueprintUrl;
 
 	@Column(nullable = false)
@@ -24,18 +27,58 @@ public class Blueprint {
 	@Column(nullable = false)
 	private Double height;
 
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "lat", column = @Column(name = "tl_lat", nullable = false)),
+		@AttributeOverride(name = "lon", column = @Column(name = "tl_lon", nullable = false))
+	})
+	private GeoPoint topLeft;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "lat", column = @Column(name = "tr_lat", nullable = false)),
+		@AttributeOverride(name = "lon", column = @Column(name = "tr_lon", nullable = false))
+	})
+	private GeoPoint topRight;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "lat", column = @Column(name = "br_lat", nullable = false)),
+		@AttributeOverride(name = "lon", column = @Column(name = "br_lon", nullable = false))
+	})
+	private GeoPoint bottomRight;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "lat", column = @Column(name = "bl_lat", nullable = false)),
+		@AttributeOverride(name = "lon", column = @Column(name = "bl_lon", nullable = false))
+	})
+	private GeoPoint bottomLeft;
+
 	@Builder
-	public Blueprint(String blueprintUrl, Integer floor, Double width, Double height) {
+	public Blueprint(String name, String blueprintUrl, Integer floor, Double width, Double height,
+		GeoPoint topLeft, GeoPoint topRight, GeoPoint bottomRight, GeoPoint bottomLeft) {
+		this.name = name;
 		this.blueprintUrl = blueprintUrl;
 		this.floor = floor;
 		this.width = width;
 		this.height = height;
+		this.topLeft = topLeft;
+		this.topRight = topRight;
+		this.bottomRight = bottomRight;
+		this.bottomLeft = bottomLeft;
 	}
 
-	public void update(String blueprintUrl, Integer floor, Double width, Double height) {
+	public void update(String name, String blueprintUrl, Integer floor, Double width, Double height,
+		GeoPoint topLeft, GeoPoint topRight, GeoPoint bottomRight, GeoPoint bottomLeft) {
+		this.name = name;
 		this.blueprintUrl = blueprintUrl;
 		this.floor = floor;
 		this.width = width;
 		this.height = height;
+		this.topLeft = topLeft;
+		this.topRight = topRight;
+		this.bottomRight = bottomRight;
+		this.bottomLeft = bottomLeft;
 	}
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/entity/GeoPoint.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/entity/GeoPoint.java
@@ -1,0 +1,16 @@
+package com.iroom.dashboard.blueprint.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeoPoint {
+	@Column(nullable = false)
+	private Double lat;
+
+	@Column(nullable = false)
+	private Double lon;
+}

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/repository/BlueprintRepository.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/repository/BlueprintRepository.java
@@ -12,4 +12,6 @@ public interface BlueprintRepository extends JpaRepository<Blueprint, Long> {
 
     Page<Blueprint> findByFloor(Integer floor, Pageable pageable);
     
+    Page<Blueprint> findByName(String name, Pageable pageable);
+    
 }

--- a/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
+++ b/dashboard/src/main/java/com/iroom/dashboard/blueprint/service/BlueprintService.java
@@ -11,8 +11,10 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
 import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest;
+import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest.GeoPointDto;
 import com.iroom.dashboard.blueprint.dto.response.BlueprintResponse;
 import com.iroom.dashboard.blueprint.entity.Blueprint;
+import com.iroom.dashboard.blueprint.entity.GeoPoint;
 import com.iroom.dashboard.blueprint.repository.BlueprintRepository;
 import com.iroom.modulecommon.dto.response.PagedResponse;
 import com.iroom.modulecommon.exception.CustomException;
@@ -21,7 +23,6 @@ import com.iroom.modulecommon.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -42,28 +43,140 @@ public class BlueprintService {
 	private String uploadDir;
 
 	private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(".png", ".jpg", ".jpeg");
-	private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
-		"image/png", "image/jpeg", "image/jpg");
+	private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList("image/png", "image/jpeg", "image/jpg");
 	private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
+	// ====== CREATE ======
 	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
 	public BlueprintResponse createBlueprint(MultipartFile file, BlueprintRequest request) {
 		String storedFilename = saveFile(file);
 		String blueprintUrl = "/uploads/blueprints/" + storedFilename;
 
+		// 코너 4개 유효성 체크
+		validateCorners(request);
+
 		Blueprint blueprint = Blueprint.builder()
+			.name(request.name())
 			.blueprintUrl(blueprintUrl)
 			.floor(request.floor())
 			.width(request.width())
 			.height(request.height())
+			.topLeft(toGeo(request.topLeft()))
+			.topRight(toGeo(request.topRight()))
+			.bottomRight(toGeo(request.bottomRight()))
+			.bottomLeft(toGeo(request.bottomLeft()))
 			.build();
+
 		return new BlueprintResponse(blueprintRepository.save(blueprint));
 	}
 
+	// ====== UPDATE ======
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
+	public BlueprintResponse updateBlueprint(Long id, BlueprintRequest request, MultipartFile file) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
+
+		String blueprintUrl = blueprint.getBlueprintUrl();
+
+		if (file != null && !file.isEmpty()) {
+			deleteExistingFile(blueprint.getBlueprintUrl());
+			String storedFilename = saveFile(file);
+			blueprintUrl = "/uploads/blueprints/" + storedFilename;
+		}
+
+		// 코너 4개 유효성 체크
+		validateCorners(request);
+
+		blueprint.update(
+			request.name(),
+			blueprintUrl,
+			request.floor(),
+			request.width(),
+			request.height(),
+			toGeo(request.topLeft()),
+			toGeo(request.topRight()),
+			toGeo(request.bottomRight()),
+			toGeo(request.bottomLeft())
+		);
+
+		return new BlueprintResponse(blueprint);
+	}
+
+	// ====== DELETE ======
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
+	public void deleteBlueprint(Long id) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
+		deleteExistingFile(blueprint.getBlueprintUrl());
+		blueprintRepository.deleteById(id);
+	}
+
+	// ====== READ (single) ======
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
+	public BlueprintResponse getBlueprint(Long id) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
+		return new BlueprintResponse(blueprint);
+	}
+
+	// ====== READ (paged list) ======
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
+	public PagedResponse<BlueprintResponse> getAllBlueprints(String target, String keyword, Integer page, Integer size) {
+		Pageable pageable = PageRequest.of(page, size);
+
+		Page<Blueprint> blueprintPage;
+		if (target == null || keyword == null || keyword.trim().isEmpty()) {
+			blueprintPage = blueprintRepository.findAll(pageable);
+		} else if ("floor".equals(target)) {
+			try {
+				Integer floor = Integer.parseInt(keyword);
+				blueprintPage = blueprintRepository.findByFloor(floor, pageable);
+			} catch (NumberFormatException e) {
+				blueprintPage = blueprintRepository.findAll(pageable);
+			}
+		} else if ("name".equals(target)) {
+			blueprintPage = blueprintRepository.findByName(keyword.trim(), pageable);
+		} else {
+			blueprintPage = blueprintRepository.findAll(pageable);
+		}
+
+		Page<BlueprintResponse> responsePage = blueprintPage.map(BlueprintResponse::new);
+		return PagedResponse.of(responsePage);
+	}
+
+	// ====== IMAGE RESOURCE ======
+	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
+	public Resource getBlueprintImageResource(Long id) {
+		Blueprint blueprint = blueprintRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
+
+		if (blueprint.getBlueprintUrl() == null || blueprint.getBlueprintUrl().isEmpty()) {
+			throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
+		}
+
+		try {
+			// 파일 경로에서 파일명 추출 (/uploads/blueprints/filename.jpg -> filename.jpg)
+			String filename = blueprint.getBlueprintUrl().substring(blueprint.getBlueprintUrl().lastIndexOf("/") + 1);
+
+			String rootPath = System.getProperty("user.dir");
+			String filePath = Paths.get(rootPath, uploadDir, filename).toString();
+
+			File file = new File(filePath);
+			if (!file.exists()) {
+				throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
+			}
+
+			return new FileSystemResource(file);
+
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
+		}
+	}
+
+	// ====== PRIVATE HELPERS ======
 	private String saveFile(MultipartFile file) {
-		// 파일 검증
 		validateFileBasic(file);
-		
+
 		File directory = createUploadDirectory();
 		String storedFilename = generateFilename(file);
 
@@ -73,10 +186,9 @@ public class BlueprintService {
 		} catch (IOException e) {
 			throw new RuntimeException("도면 파일 저장 중 오류 발생", e);
 		}
-
 		return storedFilename;
 	}
-	
+
 	private void validateFileBasic(MultipartFile file) {
 		// 파일 크기 검증
 		if (file.getSize() > MAX_FILE_SIZE) {
@@ -89,7 +201,7 @@ public class BlueprintService {
 			throw new CustomException(ErrorCode.DASHBOARD_INVALID_FILE_TYPE);
 		}
 	}
-	
+
 	private String generateFilename(MultipartFile file) {
 		String originalFilename = file.getOriginalFilename();
 		if (originalFilename == null || originalFilename.trim().isEmpty()) {
@@ -105,7 +217,7 @@ public class BlueprintService {
 		if (!ALLOWED_EXTENSIONS.contains(fileExtension)) {
 			throw new CustomException(ErrorCode.DASHBOARD_INVALID_FILE_TYPE);
 		}
-		
+
 		return UUID.randomUUID() + fileExtension;
 	}
 
@@ -122,24 +234,6 @@ public class BlueprintService {
 		return directory;
 	}
 
-
-	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
-	public BlueprintResponse updateBlueprint(Long id, BlueprintRequest request, MultipartFile file) {
-		Blueprint blueprint = blueprintRepository.findById(id)
-			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
-		
-		String blueprintUrl = blueprint.getBlueprintUrl();
-
-		if (file != null && !file.isEmpty()) {
-			deleteExistingFile(blueprint.getBlueprintUrl());
-			String storedFilename = saveFile(file);
-			blueprintUrl = "/uploads/blueprints/" + storedFilename;
-		}
-		
-		blueprint.update(blueprintUrl, request.floor(), request.width(), request.height());
-		return new BlueprintResponse(blueprint);
-	}
-	
 	private void deleteExistingFile(String blueprintUrl) {
 		if (blueprintUrl != null && !blueprintUrl.isEmpty()) {
 			try {
@@ -156,69 +250,18 @@ public class BlueprintService {
 		}
 	}
 
-	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN')")
-	public void deleteBlueprint(Long id) {
-		Blueprint blueprint = blueprintRepository.findById(id)
-			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
-		deleteExistingFile(blueprint.getBlueprintUrl());
-		blueprintRepository.deleteById(id);
-	}
-
-	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
-	public BlueprintResponse getBlueprint(Long id) {
-		Blueprint blueprint = blueprintRepository.findById(id)
-			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
-		return new BlueprintResponse(blueprint);
-	}
-
-	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
-	public PagedResponse<BlueprintResponse> getAllBlueprints(String target, String keyword, Integer page, Integer size) {
-		Pageable pageable = PageRequest.of(page, size);
-
-		Page<Blueprint> blueprintPage;
-		if (target == null || keyword == null || keyword.trim().isEmpty()) {
-			blueprintPage = blueprintRepository.findAll(pageable);
-		} else if ("floor".equals(target)) {
-			try {
-				Integer floor = Integer.parseInt(keyword);
-				blueprintPage = blueprintRepository.findByFloor(floor, pageable);
-			} catch (NumberFormatException e) {
-				blueprintPage = blueprintRepository.findAll(pageable);
-			}
-		} else {
-			blueprintPage = blueprintRepository.findAll(pageable);
+	// ---- 좌표 매핑 유틸 ----
+	private GeoPoint toGeo(GeoPointDto dto) {
+		if (dto == null || dto.lat() == null || dto.lon() == null) {
+			throw new CustomException(ErrorCode.GLOBAL_VALIDATION_FAILED);
 		}
-
-		Page<BlueprintResponse> responsePage = blueprintPage.map(BlueprintResponse::new);
-
-		return PagedResponse.of(responsePage);
+		return new GeoPoint(dto.lat(), dto.lon());
 	}
 
-	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
-	public Resource getBlueprintImageResource(Long id) {
-		Blueprint blueprint = blueprintRepository.findById(id)
-			.orElseThrow(() -> new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND));
-
-		if (blueprint.getBlueprintUrl() == null || blueprint.getBlueprintUrl().isEmpty()) {
-			throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
-		}
-
-		try {
-			// 파일 경로에서 파일명 추출 (/uploads/blueprints/filename.jpg -> filename.jpg)
-			String filename = blueprint.getBlueprintUrl().substring(blueprint.getBlueprintUrl().lastIndexOf("/") + 1);
-			
-			String rootPath = System.getProperty("user.dir");
-			String filePath = Paths.get(rootPath, uploadDir, filename).toString();
-			
-			File file = new File(filePath);
-			if (!file.exists()) {
-				throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
-			}
-			
-			return new FileSystemResource(file);
-				
-		} catch (Exception e) {
-			throw new CustomException(ErrorCode.DASHBOARD_BLUEPRINT_NOT_FOUND);
+	private void validateCorners(BlueprintRequest r) {
+		if (r.topLeft() == null || r.topRight() == null ||
+			r.bottomRight() == null || r.bottomLeft() == null) {
+			throw new CustomException(ErrorCode.GLOBAL_VALIDATION_FAILED);
 		}
 	}
 }

--- a/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/controller/BlueprintControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iroom.dashboard.blueprint.controller.BlueprintController;
 import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest;
+import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest.GeoPointDto;
 import com.iroom.dashboard.blueprint.dto.response.BlueprintResponse;
 import com.iroom.dashboard.blueprint.service.BlueprintService;
 import com.iroom.modulecommon.dto.response.PagedResponse;
@@ -55,8 +56,19 @@ class BlueprintControllerTest {
 	@DisplayName("도면 등록 성공")
 	void createBlueprintTest() throws Exception {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
-		BlueprintResponse response = new BlueprintResponse(1L, "/uploads/blueprints/test-uuid.png", 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
+		BlueprintResponse response = new BlueprintResponse(
+			1L, "Test Blueprint", "/uploads/blueprints/test-uuid.png", 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", "test content".getBytes());
 		MockMultipartFile data = new MockMultipartFile("data", "", "application/json", 
@@ -71,18 +83,32 @@ class BlueprintControllerTest {
 				.file(data)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.name").value("Test Blueprint"))
 			.andExpect(jsonPath("$.data.blueprintUrl").value("/uploads/blueprints/test-uuid.png"))
 			.andExpect(jsonPath("$.data.floor").value(1))
 			.andExpect(jsonPath("$.data.width").value(100.0))
-			.andExpect(jsonPath("$.data.height").value(200.0));
+			.andExpect(jsonPath("$.data.height").value(200.0))
+			.andExpect(jsonPath("$.data.topLeft.lat").value(37.5665))
+			.andExpect(jsonPath("$.data.topLeft.lon").value(126.9780));
 	}
 
 	@Test
 	@DisplayName("도면 수정 성공 - 파일 없이")
 	void updateBlueprintWithoutFileTest() throws Exception {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 2, 150.0, 250.0);
-		BlueprintResponse response = new BlueprintResponse(1L, "/uploads/blueprints/original.png", 2, 150.0, 250.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Updated Blueprint", null, 2, 150.0, 250.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
+		BlueprintResponse response = new BlueprintResponse(
+			1L, "Updated Blueprint", "/uploads/blueprints/original.png", 2, 150.0, 250.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		MockMultipartFile data = new MockMultipartFile("data", "", "application/json", 
 			objectMapper.writeValueAsString(request).getBytes());
@@ -99,6 +125,7 @@ class BlueprintControllerTest {
 				})
 				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.name").value("Updated Blueprint"))
 			.andExpect(jsonPath("$.data.blueprintUrl").value("/uploads/blueprints/original.png"))
 			.andExpect(jsonPath("$.data.floor").value(2));
 	}
@@ -107,8 +134,19 @@ class BlueprintControllerTest {
 	@DisplayName("도면 수정 성공 - 파일과 함께")
 	void updateBlueprintWithFileTest() throws Exception {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 2, 150.0, 250.0);
-		BlueprintResponse response = new BlueprintResponse(1L, "/uploads/blueprints/new-uuid.png", 2, 150.0, 250.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Updated Blueprint with File", null, 2, 150.0, 250.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
+		BlueprintResponse response = new BlueprintResponse(
+			1L, "Updated Blueprint with File", "/uploads/blueprints/new-uuid.png", 2, 150.0, 250.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		MockMultipartFile file = new MockMultipartFile("file", "new-test.png", "image/png", "new test content".getBytes());
 		MockMultipartFile data = new MockMultipartFile("data", "", "application/json", 
@@ -127,6 +165,7 @@ class BlueprintControllerTest {
 				})
 				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.name").value("Updated Blueprint with File"))
 			.andExpect(jsonPath("$.data.blueprintUrl").value("/uploads/blueprints/new-uuid.png"))
 			.andExpect(jsonPath("$.data.floor").value(2));
 	}
@@ -148,8 +187,19 @@ class BlueprintControllerTest {
 	@DisplayName("도면 전체 조회 성공")
 	void getAllBlueprintsTest() throws Exception {
 		// given
-		BlueprintResponse r1 = new BlueprintResponse(1L, "url1.png", 1, 100.0, 100.0);
-		BlueprintResponse r2 = new BlueprintResponse(2L, "url2.png", 2, 200.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintResponse r1 = new BlueprintResponse(
+			1L, "Blueprint 1", "url1.png", 1, 100.0, 100.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
+		BlueprintResponse r2 = new BlueprintResponse(
+			2L, "Blueprint 2", "url2.png", 2, 200.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		List<BlueprintResponse> content = List.of(r1, r2);
 		Page<BlueprintResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), content.size());

--- a/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
+++ b/dashboard/src/test/java/com/iroom/dashboard/service/BlueprintServiceTest.java
@@ -29,8 +29,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.iroom.dashboard.blueprint.service.BlueprintService;
 import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest;
+import com.iroom.dashboard.blueprint.dto.request.BlueprintRequest.GeoPointDto;
 import com.iroom.dashboard.blueprint.dto.response.BlueprintResponse;
 import com.iroom.dashboard.blueprint.entity.Blueprint;
+import com.iroom.dashboard.blueprint.entity.GeoPoint;
 import com.iroom.dashboard.blueprint.repository.BlueprintRepository;
 import com.iroom.modulecommon.dto.response.PagedResponse;
 import com.iroom.modulecommon.exception.CustomException;
@@ -67,17 +69,27 @@ class BlueprintServiceTest {
 		System.setProperty("user.dir", tempDir.toString());
 
 		blueprint = Blueprint.builder()
+			.name("Test Blueprint")
 			.blueprintUrl("/uploads/blueprints/test-uuid.png")
 			.floor(1)
 			.width(100.0)
 			.height(200.0)
+			.topLeft(new GeoPoint(37.5665, 126.9780))
+			.topRight(new GeoPoint(37.5665, 126.9790))
+			.bottomRight(new GeoPoint(37.5655, 126.9790))
+			.bottomLeft(new GeoPoint(37.5655, 126.9780))
 			.build();
 
 		Blueprint blueprint2 = Blueprint.builder()
+			.name("Test Blueprint 2")
 			.blueprintUrl("/uploads/blueprints/test-uuid2.png")
 			.floor(2)
 			.width(150.0)
 			.height(250.0)
+			.topLeft(new GeoPoint(37.5665, 126.9780))
+			.topRight(new GeoPoint(37.5665, 126.9790))
+			.bottomRight(new GeoPoint(37.5655, 126.9790))
+			.bottomLeft(new GeoPoint(37.5655, 126.9780))
 			.build();
 
 		pageable = PageRequest.of(0, 10);
@@ -135,18 +147,29 @@ class BlueprintServiceTest {
 	@DisplayName("도면 생성 성공")
 	void createBlueprintTest() {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 		given(blueprintRepository.save(any(Blueprint.class))).willReturn(blueprint);
 
 		// when
 		BlueprintResponse response = blueprintService.createBlueprint(validFile, request);
 
 		// then
+		assertThat(response.name()).isEqualTo("Test Blueprint");
 		assertThat(response.blueprintUrl()).contains("/uploads/blueprints/");
 		assertThat(response.blueprintUrl()).contains(".png");
 		assertThat(response.floor()).isEqualTo(1);
 		assertThat(response.width()).isEqualTo(100.0);
 		assertThat(response.height()).isEqualTo(200.0);
+		assertThat(response.topLeft().lat()).isEqualTo(37.5665);
+		assertThat(response.topLeft().lon()).isEqualTo(126.9780);
 		verify(blueprintRepository).save(any(Blueprint.class));
 	}
 	
@@ -154,7 +177,15 @@ class BlueprintServiceTest {
 	@DisplayName("도면 생성 실패 - 파일명이 null")
 	void createBlueprintFailNullFilename() {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		// when & then
 		assertThatThrownBy(() -> blueprintService.createBlueprint(nullNameFile, request))
@@ -167,7 +198,15 @@ class BlueprintServiceTest {
 	@DisplayName("도면 생성 실패 - 잘못된 MIME 타입")
 	void createBlueprintFailInvalidMimeType() {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		// when & then
 		assertThatThrownBy(() -> blueprintService.createBlueprint(invalidMimeTypeFile, request))
@@ -180,7 +219,15 @@ class BlueprintServiceTest {
 	@DisplayName("도면 생성 실패 - 잘못된 파일 확장자")
 	void createBlueprintFailInvalidExtension() {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		// when & then
 		assertThatThrownBy(() -> blueprintService.createBlueprint(invalidExtensionFile, request))
@@ -193,7 +240,15 @@ class BlueprintServiceTest {
 	@DisplayName("도면 생성 실패 - 파일 크기 초과")
 	void createBlueprintFailFileTooLarge() {
 		// given
-		BlueprintRequest request = new BlueprintRequest(null, 1, 100.0, 200.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 1, 100.0, 200.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 
 		// when & then
 		assertThatThrownBy(() -> blueprintService.createBlueprint(largeSizeFile, request))
@@ -207,13 +262,22 @@ class BlueprintServiceTest {
 	void updateBlueprintWithoutFileTest() {
 		// given
 		Long id = 1L;
-		BlueprintRequest request = new BlueprintRequest(null, 1, 120.0, 220.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Updated Blueprint", null, 1, 120.0, 220.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprint));
 
 		// when
 		BlueprintResponse response = blueprintService.updateBlueprint(id, request, null);
 
 		// then
+		assertThat(response.name()).isEqualTo("Updated Blueprint");
 		assertThat(response.blueprintUrl()).isEqualTo("/uploads/blueprints/test-uuid.png"); // 기존 URL 유지
 		assertThat(response.width()).isEqualTo(120.0);
 		assertThat(response.height()).isEqualTo(220.0);
@@ -224,7 +288,15 @@ class BlueprintServiceTest {
 	void updateBlueprintWithFileTest() {
 		// given
 		Long id = 1L;
-		BlueprintRequest request = new BlueprintRequest(null, 1, 120.0, 220.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Updated Blueprint with File", null, 1, 120.0, 220.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprint));
 
 		// when
@@ -243,7 +315,15 @@ class BlueprintServiceTest {
 	void updateBlueprintFailNotFound() {
 		// given
 		Long id = 99L;
-		BlueprintRequest request = new BlueprintRequest(null, 2, 50.0, 50.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Test Blueprint", null, 2, 50.0, 50.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 		given(blueprintRepository.findById(id)).willReturn(Optional.empty());
 
 		// when & then
@@ -258,7 +338,15 @@ class BlueprintServiceTest {
 	void updateBlueprintFailInvalidFile() {
 		// given
 		Long id = 1L;
-		BlueprintRequest request = new BlueprintRequest(null, 1, 120.0, 220.0);
+		GeoPointDto topLeft = new GeoPointDto(37.5665, 126.9780);
+		GeoPointDto topRight = new GeoPointDto(37.5665, 126.9790);
+		GeoPointDto bottomRight = new GeoPointDto(37.5655, 126.9790);
+		GeoPointDto bottomLeft = new GeoPointDto(37.5655, 126.9780);
+		
+		BlueprintRequest request = new BlueprintRequest(
+			"Updated Blueprint", null, 1, 120.0, 220.0,
+			topLeft, topRight, bottomRight, bottomLeft
+		);
 		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprint));
 
 		// when & then
@@ -325,10 +413,15 @@ class BlueprintServiceTest {
 		testFile.createNewFile();
 		
 		Blueprint blueprintWithImage = Blueprint.builder()
+			.name("Test Blueprint with Image")
 			.blueprintUrl("/uploads/blueprints/test-image.png")
 			.floor(1)
 			.width(100.0)
 			.height(200.0)
+			.topLeft(new GeoPoint(37.5665, 126.9780))
+			.topRight(new GeoPoint(37.5665, 126.9790))
+			.bottomRight(new GeoPoint(37.5655, 126.9790))
+			.bottomLeft(new GeoPoint(37.5655, 126.9780))
 			.build();
 			
 		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprintWithImage));
@@ -361,10 +454,15 @@ class BlueprintServiceTest {
 		// given
 		Long id = 1L;
 		Blueprint blueprintWithNullUrl = Blueprint.builder()
+			.name("Blueprint with Null URL")
 			.blueprintUrl(null)
 			.floor(1)
 			.width(100.0)
 			.height(200.0)
+			.topLeft(new GeoPoint(37.5665, 126.9780))
+			.topRight(new GeoPoint(37.5665, 126.9790))
+			.bottomRight(new GeoPoint(37.5655, 126.9790))
+			.bottomLeft(new GeoPoint(37.5655, 126.9780))
 			.build();
 			
 		given(blueprintRepository.findById(id)).willReturn(Optional.of(blueprintWithNullUrl));

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -552,6 +552,33 @@ export const blueprintAPI = {
 };
 
 /**
+ * Alarm API 서비스
+ */
+export const alarmAPI = {
+    /**
+     * 관리자용 알람 목록 조회
+     * @param {object} options
+     * @param {number} options.page - 페이지 번호 (기본값: 0)
+     * @param {number} options.size - 페이지당 개수 (기본값: 10)
+     * @param {number} [options.hours] - 최근 N시간 내 알람 (선택사항)
+     * @returns {Promise} 알람 목록 데이터
+     */
+    getAlarmsForAdmin: async ({page = 0, size = 10, hours} = {}) => {
+        const queryParams = new URLSearchParams({
+            page: page.toString(),
+            size: size.toString(),
+        });
+
+        if (hours !== undefined) {
+            queryParams.append('hours', hours.toString());
+        }
+
+        const url = `${API_CONFIG.gateway}/api/alarm/alarms/admins?${queryParams.toString()}`;
+        return await apiRequest(url);
+    }
+};
+
+/**
  * Risk Zone (Danger Area) API 서비스
  */
 export const riskZoneAPI = {

--- a/frontend/src/components/AlarmModal.js
+++ b/frontend/src/components/AlarmModal.js
@@ -1,0 +1,161 @@
+import React, { useState, useEffect } from 'react';
+import styles from '../styles/AlarmModal.module.css';
+import { alarmAPI } from '../api/api';
+import { useAlarmData } from '../hooks/useAlarmData';
+
+const AlarmModal = ({ isOpen, onClose }) => {
+    const [alarms, setAlarms] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [pagination, setPagination] = useState({
+        page: 0,
+        size: 10,
+        hours: 168,
+        totalPages: 0,
+        totalElements: 0
+    });
+    
+    const { getAlertIcon, transformAlarmData } = useAlarmData();
+
+
+    // 알림 목록 로드
+    const loadAlarms = async (page = 0, hours = pagination.hours) => {
+        setLoading(true);
+        try {
+            const response = await alarmAPI.getAlarmsForAdmin({
+                page: page,
+                size: pagination.size,
+                hours: hours
+            });
+
+            const apiAlarms = response.data?.content?.map(transformAlarmData) || [];
+
+            setAlarms(apiAlarms);
+            setPagination(prev => ({
+                ...prev,
+                page: page,
+                size: prev.size,
+                hours: hours,
+                totalPages: response.data?.totalPages || 0,
+                totalElements: response.data?.totalElements || 0
+            }));
+        } catch (error) {
+            console.error('❌ 알람 목록 로드 실패:', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // 모달이 열릴 때 데이터 로드
+    useEffect(() => {
+        if (isOpen) {
+            loadAlarms(0).catch(console.error);
+        }
+    }, [isOpen]);
+
+    // 페이지 변경
+    const handlePageChange = (newPage) => {
+        if (newPage >= 0 && newPage < pagination.totalPages) {
+            loadAlarms(newPage).catch(console.error);
+        }
+    };
+
+    // 모달이 닫혀있으면 렌더링하지 않음
+    if (!isOpen) return null;
+
+    return (
+        <div className={styles.modalOverlay} onClick={onClose}>
+            <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+                {/* 모달 헤더 */}
+                <div className={styles.modalHeader}>
+                    <div className={styles.headerLeft}>
+                        <h2 className={styles.modalTitle}>실시간 위험 알림</h2>
+                        <select 
+                            className={styles.hoursSelect}
+                            value={pagination.hours}
+                            onChange={(e) => {
+                                const newHours = parseInt(e.target.value);
+                                setPagination(prev => ({
+                                    ...prev,
+                                    page: 0,
+                                    size: prev.size,
+                                    hours: newHours,
+                                    totalPages: prev.totalPages,
+                                    totalElements: prev.totalElements
+                                }));
+                                loadAlarms(0, newHours).catch(console.error);
+                            }}
+                        >
+                            <option value={1}>최근 1시간</option>
+                            <option value={3}>최근 3시간</option>
+                            <option value={6}>최근 6시간</option>
+                            <option value={12}>최근 12시간</option>
+                            <option value={24}>최근 24시간</option>
+                            <option value={72}>최근 3일</option>
+                            <option value={168}>최근 7일</option>
+                        </select>
+                    </div>
+                    <button className={styles.closeButton} onClick={onClose}>
+                        ×
+                    </button>
+                </div>
+
+                {/* 알림 목록 */}
+                <div className={styles.modalBody}>
+                    {loading ? (
+                        <div className={styles.loadingState}>
+                            📡 알림 목록을 불러오는 중...
+                        </div>
+                    ) : alarms.length > 0 ? (
+                        <>
+                            <div className={styles.alarmList}>
+                                {alarms.map(alarm => (
+                                    <div key={alarm.id} className={`${styles.alarmItem} ${styles[alarm.type]}`}>
+                                        <div className={`${styles.alarmIcon} ${styles[alarm.type]}`}>
+                                            {getAlertIcon(alarm.type)}
+                                        </div>
+                                        <div className={styles.alarmContent}>
+                                            <p className={styles.alarmTitle}>{alarm.title}</p>
+                                            <p className={styles.alarmDesc}>{alarm.description}</p>
+                                            <p className={styles.alarmMeta}>작업자 ID: {alarm.workerId}</p>
+                                        </div>
+                                        <span className={styles.alarmTime}>{alarm.time}</span>
+                                    </div>
+                                ))}
+                            </div>
+
+                            {/* 페이지네이션 */}
+                            <div className={styles.pagination}>
+                                <button 
+                                    className={styles.pageButton}
+                                    disabled={pagination.page === 0}
+                                    onClick={() => handlePageChange(pagination.page - 1)}
+                                >
+                                    이전
+                                </button>
+                                
+                                <span className={styles.pageInfo}>
+                                    {pagination.page + 1} / {pagination.totalPages} 페이지
+                                    (총 {pagination.totalElements}건)
+                                </span>
+                                
+                                <button 
+                                    className={styles.pageButton}
+                                    disabled={pagination.page >= pagination.totalPages - 1}
+                                    onClick={() => handlePageChange(pagination.page + 1)}
+                                >
+                                    다음
+                                </button>
+                            </div>
+                        </>
+                    ) : (
+                        <div className={styles.emptyState}>
+                            📋 최근 {pagination.hours}시간 내 알림이 없습니다.
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AlarmModal;

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -18,20 +18,17 @@ const Header = () => {
         const connectWebSocket = async () => {
             try {
                 await stompService.connect(token, 'admin');
-                console.log('✅ Header: 웹소켓 연결 성공');
             } catch (error) {
-                console.error('❌ Header: 웹소켓 연결 실패:', error);
             }
         };
 
         // 알림 이벤트 리스너 등록
         const handleNewAlarm = (data) => {
-            console.log('🔔 Header: 새로운 알림 수신:', data);
             const newNotification = createNotificationFromWebSocket(data);
             
             setNotifications(prev => [newNotification, ...prev.slice(0, 49)]); // 최대 50개 유지
             
-            // 토스트 알림 표시 (App.js에서 처리할 예정)
+            // 토스트 알림 표시
             window.dispatchEvent(new CustomEvent('showNotificationToast', { 
                 detail: newNotification 
             }));
@@ -42,10 +39,9 @@ const Header = () => {
 
         // 웹소켓 연결
         if (!stompService.isConnected()) {
-            connectWebSocket();
+            connectWebSocket().catch(console.error);
         }
 
-        // 클린업
         return () => {
             stompService.off('alarm', handleNewAlarm);
         };

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -8,7 +8,6 @@ const Header = () => {
     // 알림 상태 관리
     const [notifications, setNotifications] = useState([]);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
 
     // 웹소켓 연결 및 이벤트 처리
     useEffect(() => {
@@ -19,11 +18,9 @@ const Header = () => {
         const connectWebSocket = async () => {
             try {
                 await stompService.connect(token, 'admin');
-                setIsWebSocketConnected(true);
                 console.log('✅ Header: 웹소켓 연결 성공');
             } catch (error) {
                 console.error('❌ Header: 웹소켓 연결 실패:', error);
-                setIsWebSocketConnected(false);
             }
         };
 
@@ -42,14 +39,10 @@ const Header = () => {
 
         // 이벤트 리스너 등록
         stompService.on('alarm', handleNewAlarm);
-        stompService.on('connected', () => setIsWebSocketConnected(true));
-        stompService.on('disconnected', () => setIsWebSocketConnected(false));
 
         // 웹소켓 연결
         if (!stompService.isConnected()) {
             connectWebSocket();
-        } else {
-            setIsWebSocketConnected(true);
         }
 
         // 클린업

--- a/frontend/src/components/WorkerAddModal.js
+++ b/frontend/src/components/WorkerAddModal.js
@@ -18,13 +18,16 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
     };
 
     const [addForm, setAddForm] = useState(initialFormData);
+    const [loading, setLoading] = useState(false);
 
     const handleInputChange = (e) => {
         const {name, value} = e.target;
         setAddForm(prev => ({...prev, [name]: value}));
     };
 
-    const handleSave = () => {
+    const handleSave = async () => {
+        if (loading) return;
+        
         // 필수 필드 검증
         if (!addForm.name || !addForm.name.trim()) {
             alert('이름을 입력해주세요.');
@@ -68,14 +71,29 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
             return;
         }
 
-        if (addForm.password.length < 8) {
-            alert('비밀번호는 8자 이상이어야 합니다.');
+        const pwd = addForm.password;
+        if (pwd.length < 8 || pwd.length > 16) {
+            alert('비밀번호는 8-16자여야 합니다.');
             return;
         }
 
-        const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
-        if (!passwordRegex.test(addForm.password)) {
-            alert('비밀번호는 영문과 숫자를 포함하여 8자 이상이어야 합니다.');
+        if (!/.*[a-zA-Z].*/.test(pwd)) {
+            alert('영문자를 포함해야 합니다.');
+            return;
+        }
+
+        if (!/.*\d.*/.test(pwd)) {
+            alert('숫자를 포함해야 합니다.');
+            return;
+        }
+
+        if (!/[#$%&*+,./:=?@[\\\]^_`{|}~!-]/.test(pwd)) {
+            alert('특수문자를 포함해야 합니다.');
+            return;
+        }
+
+        if (/[()<>'";}]/.test(pwd)) {
+            alert('특수문자 ()<>"\';는 사용할 수 없습니다.');
             return;
         }
 
@@ -97,9 +115,16 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
             return;
         }
 
-        onSave(addForm);
-        // 폼을 예시값으로 초기화
-        setAddForm(initialFormData);
+        try {
+            setLoading(true);
+            await onSave(addForm);
+            // 폼을 예시값으로 초기화
+            setAddForm(initialFormData);
+        } catch (error) {
+            console.error('근로자 등록 실패:', error);
+        } finally {
+            setLoading(false);
+        }
     };
 
     const handleClose = () => {
@@ -117,8 +142,9 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
         borderRadius: '8px',
         fontSize: '14px',
         outline: 'none',
-        backgroundColor: '#fafafa',
-        boxSizing: 'border-box'
+        backgroundColor: loading ? '#f3f4f6' : '#fafafa',
+        boxSizing: 'border-box',
+        opacity: loading ? 0.6 : 1
     };
 
     const labelStyle = {
@@ -215,6 +241,7 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="name"
                                     value={addForm.name}
                                     onChange={handleInputChange}
+                                    disabled={loading}
                                     style={inputStyle}
                                 />
                             </div>
@@ -225,6 +252,7 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="department"
                                     value={addForm.department}
                                     onChange={handleInputChange}
+                                    disabled={loading}
                                     style={inputStyle}
                                 />
                             </div>
@@ -235,6 +263,7 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="occupation"
                                     value={addForm.occupation}
                                     onChange={handleInputChange}
+                                    disabled={loading}
                                     style={inputStyle}
                                 />
                             </div>
@@ -245,6 +274,7 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="jobTitle"
                                     value={addForm.jobTitle}
                                     onChange={handleInputChange}
+                                    disabled={loading}
                                     style={inputStyle}
                                 />
                             </div>
@@ -278,7 +308,8 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="gender"
                                     value={addForm.gender}
                                     onChange={handleInputChange}
-                                    style={{...inputStyle, cursor: 'pointer'}}
+                                    disabled={loading}
+                                    style={{...inputStyle, cursor: loading ? 'not-allowed' : 'pointer'}}
                                 >
                                     <option value="MALE">남성</option>
                                     <option value="FEMALE">여성</option>
@@ -317,7 +348,8 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="bloodType"
                                     value={addForm.bloodType}
                                     onChange={handleInputChange}
-                                    style={{...inputStyle, cursor: 'pointer'}}
+                                    disabled={loading}
+                                    style={{...inputStyle, cursor: loading ? 'not-allowed' : 'pointer'}}
                                 >
                                     <option value="">혈액형 선택</option>
                                     <option value="A">A형</option>
@@ -349,6 +381,7 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                                     name="age"
                                     value={addForm.age}
                                     onChange={handleInputChange}
+                                    disabled={loading}
                                     style={inputStyle}
                                 />
                             </div>
@@ -401,17 +434,18 @@ const WorkerAddModal = ({isOpen, onClose, onSave}) => {
                         </button>
                         <button
                             onClick={handleSave}
+                            disabled={loading}
                             style={{
                                 padding: '10px 20px',
                                 border: 'none',
                                 borderRadius: '6px',
-                                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                                background: loading ? '#9ca3af' : 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
                                 color: 'white',
-                                cursor: 'pointer',
+                                cursor: loading ? 'not-allowed' : 'pointer',
                                 fontSize: '14px'
                             }}
                         >
-                            등록하기
+                            {loading ? '등록 중...' : '등록하기'}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/components/notifications/NotificationDropdown.js
+++ b/frontend/src/components/notifications/NotificationDropdown.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import { X, AlertTriangle, Shield, Activity, Info, Clock, Bell } from 'lucide-react';
+import React, {useEffect, useRef} from 'react';
+import {Activity, AlertTriangle, Bell, Clock, Info, Shield, X} from 'lucide-react';
 
 const NotificationDropdown = ({ 
     isOpen, 

--- a/frontend/src/components/notifications/NotificationToast.js
+++ b/frontend/src/components/notifications/NotificationToast.js
@@ -85,35 +85,35 @@ const NotificationToast = ({
             case 'SAFETY_GEAR':
             case 'PPE_VIOLATION':
                 return {
-                    icon: <Shield size={20} />,
-                    color: '#ef4444',
-                    bgColor: '#fef2f2',
-                    borderColor: '#fecaca'
-                };
-            case 'DANGER_ZONE':
-                return {
-                    icon: <AlertTriangle size={20} />,
+                    icon: '🦺',
                     color: '#f59e0b',
                     bgColor: '#fffbeb',
                     borderColor: '#fed7aa'
                 };
+            case 'DANGER_ZONE':
+                return {
+                    icon: '⚠️',
+                    color: '#ef4444',
+                    bgColor: '#fef2f2',
+                    borderColor: '#fecaca'
+                };
             case 'HEALTH_RISK':
                 return {
-                    icon: <Activity size={20} />,
-                    color: '#8b5cf6',
-                    bgColor: '#f5f3ff',
-                    borderColor: '#c4b5fd'
+                    icon: '🏥',
+                    color: '#3b82f6',
+                    bgColor: '#eff6ff',
+                    borderColor: '#bfdbfe'
                 };
             case 'SUCCESS':
                 return {
-                    icon: <CheckCircle size={20} />,
+                    icon: '✅',
                     color: '#10b981',
                     bgColor: '#ecfdf5',
                     borderColor: '#a7f3d0'
                 };
             default:
                 return {
-                    icon: <Info size={20} />,
+                    icon: 'ℹ️',
                     color: '#3b82f6',
                     bgColor: '#eff6ff',
                     borderColor: '#bfdbfe'
@@ -133,7 +133,7 @@ const NotificationToast = ({
     };
 
     const iconStyle = {
-        color: typeConfig.color,
+        fontSize: '20px',
         flexShrink: 0
     };
 

--- a/frontend/src/components/notifications/NotificationToast.js
+++ b/frontend/src/components/notifications/NotificationToast.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { X, AlertTriangle, Shield, Activity, Info, CheckCircle } from 'lucide-react';
+import React, {useEffect, useState} from 'react';
+import {X} from 'lucide-react';
 
 const NotificationToast = ({ 
     notification, 

--- a/frontend/src/hooks/useAlarmData.js
+++ b/frontend/src/hooks/useAlarmData.js
@@ -1,0 +1,107 @@
+import { useCallback } from 'react';
+
+// 알림 데이터 관련 로직을 처리하는 Custom Hook
+export const useAlarmData = () => {
+    // 알림 타입 결정 함수
+    const getAlertTypeFromData = useCallback((incidentType, description) => {
+        const normalizedType = incidentType?.replace(/[ -]+/g, '_').toUpperCase() || '';
+        
+        if (['PPE_VIOLATION', 'DANGER_ZONE', 'HEALTH_RISK'].includes(normalizedType)) {
+            return normalizedType;
+        }
+        
+        const lowerDescription = description?.toLowerCase() || '';
+        
+        if (lowerDescription.includes('보호구') || lowerDescription.includes('미착용')) {
+            return 'PPE_VIOLATION';
+        } else if (lowerDescription.includes('위험구역') || lowerDescription.includes('위험')) {
+            return 'DANGER_ZONE';
+        } else if (lowerDescription.includes('건강') || lowerDescription.includes('심박수')) {
+            return 'HEALTH_RISK';
+        }
+        
+        return 'PPE_VIOLATION';
+    }, []);
+
+    // 알림 타입을 대시보드 타입으로 변환
+    const convertToDashboardType = useCallback((alertType) => {
+        switch (alertType) {
+            case 'PPE_VIOLATION':
+                return 'warning'; // 노란색/주황 - 보호구 미착용
+            case 'DANGER_ZONE':
+                return 'danger';  // 빨간색 - 위험구역 접근
+            case 'HEALTH_RISK':
+                return 'health';  // 파란색 - 건강 위험
+            default:
+                return 'warning';
+        }
+    }, []);
+
+    // 알림 제목 생성
+    const getAlertTitle = useCallback((alertType, description) => {
+        switch (alertType) {
+            case 'PPE_VIOLATION':
+                return '보호구 미착용';
+            case 'DANGER_ZONE':
+                return '위험구역 접근 경고';
+            case 'HEALTH_RISK':
+                return '피로도 위험';
+            default:
+                return description || '안전 알림';
+        }
+    }, []);
+
+    // 알림 아이콘 가져오기
+    const getAlertIcon = useCallback((type) => {
+        switch (type) {
+            case 'warning': return '🦺';  // PPE_VIOLATION - 보호구 미착용
+            case 'danger': return '⚠️';   // DANGER_ZONE - 위험구역 접근
+            case 'health': return '🏥';   // HEALTH_RISK - 건강 위험
+            default: return '⚠️';
+        }
+    }, []);
+
+    // 시간 포맷팅 (상대시간으로 변환)
+    const getTimeAgo = useCallback((timestamp) => {
+        if (!timestamp) return '방금 전';
+        
+        const now = new Date();
+        const time = new Date(timestamp);
+        const diffInMinutes = Math.floor((now - time) / (1000 * 60));
+        
+        if (diffInMinutes < 1) return '방금 전';
+        if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
+        
+        const diffInHours = Math.floor(diffInMinutes / 60);
+        if (diffInHours < 24) return `${diffInHours}시간 전`;
+        
+        const diffInDays = Math.floor(diffInHours / 24);
+        return `${diffInDays}일 전`;
+    }, []);
+
+    // 알림 데이터 변환 (API 응답을 대시보드용 포맷으로 변환)
+    const transformAlarmData = useCallback((alarm) => {
+        const alertType = getAlertTypeFromData(alarm.incidentType, alarm.incidentDescription);
+        const dashboardType = convertToDashboardType(alertType);
+        
+        return {
+            id: alarm.id,
+            type: dashboardType,
+            title: getAlertTitle(alertType, alarm.incidentDescription),
+            description: alarm.incidentDescription || '알림 내용',
+            time: getTimeAgo(alarm.createdAt),
+            timestamp: alarm.createdAt,
+            workerId: alarm.workerId,
+            originalData: alarm
+        };
+    }, [getAlertTypeFromData, convertToDashboardType, getAlertTitle, getTimeAgo]);
+
+    return {
+        getAlertTypeFromData,
+        convertToDashboardType,
+        getAlertTitle,
+        getAlertIcon,
+        getTimeAgo,
+        transformAlarmData
+    };
+};

--- a/frontend/src/pages/MonitoringPage.js
+++ b/frontend/src/pages/MonitoringPage.js
@@ -1,11 +1,10 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 import styles from '../styles/Monitoring.module.css';
 import AlarmModal from '../components/AlarmModal';
 import stompService from '../services/stompService';
 import { authUtils } from '../utils/auth';
-import { alarmAPI } from '../api/api';
+import { alarmAPI, blueprintAPI, riskZoneAPI } from '../api/api';
 import { useAlarmData } from '../hooks/useAlarmData';
-// import { riskZoneAPI } from '../api/api'; // API 연동 시 사용
 
 const MonitoringPage = () => {
     const mapRef = useRef(null);
@@ -17,23 +16,25 @@ const MonitoringPage = () => {
     
     const { getAlertIcon, getAlertTypeFromData, convertToDashboardType, getAlertTitle, getTimeAgo } = useAlarmData();
 
-    // 작업자 위치 데이터
+    // 작업자 위치 데이터 (GPS 좌표 기반 - 실제로는 API에서 가져와야 함)
     const [workers] = useState([
-        {id: 1, x: 15, y: 25, status: 'danger', name: '김철수'},
-        {id: 2, x: 45, y: 15, status: 'warning', name: '이영희'},
-        {id: 3, x: 75, y: 30, status: 'safe', name: '박민수'},
-        {id: 4, x: 85, y: 45, status: 'safe', name: '정수진'},
-        {id: 5, x: 25, y: 60, status: 'warning', name: '한지민'},
-        {id: 6, x: 65, y: 70, status: 'safe', name: '조현우'},
-        {id: 7, x: 55, y: 50, status: 'danger', name: '윤서연'},
-        {id: 8, x: 35, y: 80, status: 'safe', name: '장동건'}
+        {id: 1, latitude: 37.5665, longitude: 126.9780, status: 'danger', name: '김철수'},
+        {id: 2, latitude: 37.5666, longitude: 126.9781, status: 'warning', name: '이영희'},
+        {id: 3, latitude: 37.5667, longitude: 126.9782, status: 'safe', name: '박민수'},
+        {id: 4, latitude: 37.5668, longitude: 126.9783, status: 'safe', name: '정수진'},
+        {id: 5, latitude: 37.5669, longitude: 126.9784, status: 'warning', name: '한지민'},
+        {id: 6, latitude: 37.5670, longitude: 126.9785, status: 'safe', name: '조현우'},
+        {id: 7, latitude: 37.5671, longitude: 126.9786, status: 'danger', name: '윤서연'},
+        {id: 8, latitude: 37.5672, longitude: 126.9787, status: 'safe', name: '장동건'}
     ]);
 
-    // 위험구역 데이터
-    const [dangerZones] = useState([
-        {id: 1, x: 15, y: 15, width: 25, height: 35, level: 'high', name: '고위험구역'},
-        {id: 2, x: 45, y: 35, width: 20, height: 20, level: 'medium', name: '중위험구역'}
-    ]);
+    // 도면 관련 상태
+    const [currentBlueprint, setCurrentBlueprint] = useState(null);
+    const [blueprintImage, setBlueprintImage] = useState(null);
+    const [availableBlueprints, setAvailableBlueprints] = useState([]);
+
+    // 위험구역 데이터 (실제 API에서 가져옴)
+    const [dangerZones, setDangerZones] = useState([]);
 
     // 현장 현황 데이터
     const [fieldStatus] = useState({
@@ -54,6 +55,267 @@ const MonitoringPage = () => {
 
     // 알림 모달 상태
     const [isAlarmModalOpen, setIsAlarmModalOpen] = useState(false);
+
+    // 사용 가능한 도면 목록 조회
+    const fetchAvailableBlueprints = useCallback(async () => {
+        try {
+            const response = await blueprintAPI.getBlueprints({
+                page: 0,
+                size: 50
+            });
+
+            if (response.status === 'success' && response.data) {
+                const data = response.data;
+                const blueprints = data.content || [];
+                setAvailableBlueprints(blueprints);
+            } else {
+                setAvailableBlueprints([]);
+            }
+        } catch (error) {
+            console.error('도면 목록 조회 실패:', error);
+            setAvailableBlueprints([]);
+        }
+    }, []);
+
+    // 특정 도면 선택 및 로드
+    const selectBlueprint = useCallback(async (blueprintId) => {
+        if (!blueprintId) {
+            setCurrentBlueprint(null);
+            setBlueprintImage(null);
+            setDangerZones([]);
+            return;
+        }
+
+        try {
+            const blueprint = availableBlueprints.find(bp => bp.id === parseInt(blueprintId));
+            if (blueprint) {
+                setCurrentBlueprint(blueprint);
+                console.log(`도면 선택됨 - ID: ${blueprint.id}, Name: ${blueprint.name || `${blueprint.floor}층`}`);
+                console.log('4개 꼭짓점 좌표:', {
+                    topLeft: blueprint.topLeft,
+                    topRight: blueprint.topRight,
+                    bottomRight: blueprint.bottomRight,
+                    bottomLeft: blueprint.bottomLeft
+                });
+                
+                // 도면 이미지 Blob URL 생성
+                try {
+                    const blobUrl = await blueprintAPI.getBlueprintImageBlob(blueprint.id);
+                    setBlueprintImage(blobUrl);
+                } catch (imageError) {
+                    console.error('도면 이미지 로드 실패:', imageError);
+                    setBlueprintImage(null);
+                }
+
+                // 해당 도면의 위험구역 데이터 조회
+                await fetchRiskZonesForBlueprint(blueprint.id);
+            } else {
+                console.warn(`Blueprint ID ${blueprintId}를 찾을 수 없습니다.`);
+                setCurrentBlueprint(null);
+                setBlueprintImage(null);
+                setDangerZones([]);
+            }
+        } catch (error) {
+            console.error('도면 선택 실패:', error);
+            setCurrentBlueprint(null);
+            setBlueprintImage(null);
+            setDangerZones([]);
+        }
+    }, [availableBlueprints]);
+
+    // 특정 도면의 위험구역 데이터 조회
+    const fetchRiskZonesForBlueprint = useCallback(async (blueprintId) => {
+        try {
+            const response = await riskZoneAPI.getRiskZones({
+                page: 0,
+                size: 100, // 모든 위험구역 가져오기
+                blueprintId: blueprintId // 특정 도면의 위험구역만
+            });
+
+            const data = response.data || response;
+            const zones = data.content || [];
+            
+            console.log(`MonitoringPage - Blueprint ${blueprintId}의 위험구역 조회 결과:`, {
+                총개수: zones.length,
+                위험구역들: zones.map(z => ({ id: z.id, name: z.name, lat: z.latitude, lon: z.longitude }))
+            });
+            
+            // 위험구역을 화면에 표시하기 위한 형태로 변환
+            const formattedZones = zones
+                .map(zone => {
+                    // GPS 좌표를 캔버스 좌표로 변환
+                    const canvasPosition = convertGPSToCanvas(zone.latitude, zone.longitude);
+                    const canvasSize = convertMetersToCanvas(zone.width, zone.height);
+                    
+                    // 중심점 기준으로 박스 위치 계산
+                    const boxX = canvasPosition.x - canvasSize.width / 2;
+                    const boxY = canvasPosition.y - canvasSize.height / 2;
+                    
+                    console.log(`위험구역 ${zone.id} 변환:`, {
+                        GPS: { lat: zone.latitude, lon: zone.longitude },
+                        캔버스중심: canvasPosition,
+                        박스크기: canvasSize,
+                        최종박스: { x: boxX, y: boxY, width: canvasSize.width, height: canvasSize.height },
+                        도면내부여부: isInsideBlueprint(canvasPosition.x, canvasPosition.y)
+                    });
+                    
+                    return {
+                        id: zone.id,
+                        x: boxX,
+                        y: boxY,
+                        width: canvasSize.width,
+                        height: canvasSize.height,
+                        level: 'high', // 기본값, 필요시 API에서 레벨 정보 추가
+                        name: zone.name || `위험구역 ${zone.id}`,
+                        isInside: isInsideBlueprint(canvasPosition.x, canvasPosition.y), // 도면 영역 내부 여부
+                        centerX: canvasPosition.x, // 디버깅용
+                        centerY: canvasPosition.y  // 디버깅용
+                    };
+                })
+                .filter(zone => {
+                    // 도면 영역 밖의 위험구역은 필터링 (옵션)
+                    if (!zone.isInside) {
+                        console.warn(`위험구역 ${zone.id}(${zone.name})이 도면 영역을 벗어났습니다.`, 
+                            { center: { x: zone.centerX, y: zone.centerY } });
+                        return false; // 도면 밖 위험구역 제외
+                    }
+                    return true;
+                });
+            
+            console.log(`MonitoringPage - 필터링 후 최종 위험구역:`, {
+                필터링전개수: zones.length,
+                필터링후개수: formattedZones.length,
+                제거된개수: zones.length - formattedZones.length,
+                최종위험구역들: formattedZones.map(z => ({ id: z.id, name: z.name, x: z.x, y: z.y, isInside: z.isInside }))
+            });
+            
+            setDangerZones(formattedZones);
+        } catch (error) {
+            console.error('위험구역 데이터 조회 실패:', error);
+            setDangerZones([]);
+        }
+    }, []);
+
+    // GPS 좌표를 캔버스 좌표로 변환 (RiskZonePage convertCanvasToGPS의 역변환)
+    const convertGPSToCanvas = (lat, lon) => {
+        if (!currentBlueprint || !currentBlueprint.topLeft || !currentBlueprint.topRight || 
+            !currentBlueprint.bottomLeft || !currentBlueprint.bottomRight) {
+            return { x: 50, y: 50 }; // 기본값
+        }
+
+        const { topLeft, topRight, bottomLeft, bottomRight } = currentBlueprint;
+        
+        // 더 정확한 그리드 서치로 최적의 u, v 찾기 (정밀도 향상: 0.01 → 0.005)
+        let bestU = 0.5, bestV = 0.5;
+        let minError = Infinity;
+        
+        // 1차: 거친 그리드 서치 (0.05 간격)
+        for (let u = 0; u <= 1; u += 0.05) {
+            for (let v = 0; v <= 1; v += 0.05) {
+                const expectedLat = (1-u)*(1-v)*topLeft.lat + u*(1-v)*topRight.lat + 
+                                   (1-u)*v*bottomLeft.lat + u*v*bottomRight.lat;
+                const expectedLon = (1-u)*(1-v)*topLeft.lon + u*(1-v)*topRight.lon + 
+                                   (1-u)*v*bottomLeft.lon + u*v*bottomRight.lon;
+                
+                const error = Math.abs(expectedLat - lat) + Math.abs(expectedLon - lon);
+                
+                if (error < minError) {
+                    minError = error;
+                    bestU = u;
+                    bestV = v;
+                }
+            }
+        }
+        
+        // 2차: 세밀한 그리드 서치 (bestU, bestV 주변 0.002 간격)
+        const searchRange = 0.05;
+        const step = 0.002;
+        const minU = Math.max(0, bestU - searchRange);
+        const maxU = Math.min(1, bestU + searchRange);
+        const minV = Math.max(0, bestV - searchRange);
+        const maxV = Math.min(1, bestV + searchRange);
+        
+        for (let u = minU; u <= maxU; u += step) {
+            for (let v = minV; v <= maxV; v += step) {
+                const expectedLat = (1-u)*(1-v)*topLeft.lat + u*(1-v)*topRight.lat + 
+                                   (1-u)*v*bottomLeft.lat + u*v*bottomRight.lat;
+                const expectedLon = (1-u)*(1-v)*topLeft.lon + u*(1-v)*topRight.lon + 
+                                   (1-u)*v*bottomLeft.lon + u*v*bottomRight.lon;
+                
+                const error = Math.abs(expectedLat - lat) + Math.abs(expectedLon - lon);
+                
+                if (error < minError) {
+                    minError = error;
+                    bestU = u;
+                    bestV = v;
+                }
+            }
+        }
+        
+        // 정규화된 좌표를 캔버스 좌표(%)로 변환
+        const x = bestU * 100;
+        const y = bestV * 100;
+        
+        return { x: Math.max(0, Math.min(100, x)), y: Math.max(0, Math.min(100, y)) };
+    };
+
+    // 미터를 캔버스 크기로 변환 (RiskZonePage와 동일한 로직)
+    const convertMetersToCanvas = (widthMeters, heightMeters) => {
+        if (!currentBlueprint || !currentBlueprint.width || !currentBlueprint.height) {
+            return { width: 5, height: 5 }; // 기본값
+        }
+
+        console.log('박스 크기 변환:', {
+            입력크기: { width: widthMeters, height: heightMeters },
+            도면크기: { width: currentBlueprint.width, height: currentBlueprint.height },
+            단위: '미터'
+        });
+
+        // Blueprint의 width, height가 픽셀이면 실제 건물 크기로 가정
+        // 예: 1920x1080 픽셀 → 192m x 108m 건물로 가정 (1픽셀 = 0.1m)
+        let realBuildingWidth, realBuildingHeight;
+        
+        if (currentBlueprint.width > 100) {
+            // 픽셀로 추정 (1920 같은 큰 값)
+            realBuildingWidth = currentBlueprint.width * 0.05; // 1픽셀 = 5cm로 가정
+            realBuildingHeight = currentBlueprint.height * 0.05;
+        } else {
+            // 이미 미터 단위로 추정
+            realBuildingWidth = currentBlueprint.width;
+            realBuildingHeight = currentBlueprint.height;
+        }
+
+        console.log('실제 건물 크기 (추정):', { width: realBuildingWidth, height: realBuildingHeight });
+
+        // 박스 크기를 각각 독립적으로 계산
+        let widthRatio = (widthMeters / realBuildingWidth);
+        let heightRatio = (heightMeters / realBuildingHeight);
+        
+        // 박스가 너무 크면 (30% 이상) 스케일 다운
+        if (widthRatio > 0.3) {
+            widthRatio = widthRatio * 0.3; // 30% 이하로 제한
+        }
+        if (heightRatio > 0.3) {
+            heightRatio = heightRatio * 0.3; // 30% 이하로 제한
+        }
+        
+        const canvasWidth = widthRatio * 80; // 80% 영역 사용
+        const canvasHeight = heightRatio * 80; // 80% 영역 사용
+        
+        const result = { width: canvasWidth, height: canvasHeight };
+        console.log('캔버스 크기 (%):', result);
+        
+        return result;
+    };
+
+    // 도면 이미지 영역 내부인지 확인 (RiskZonePage와 동일)
+    const isInsideBlueprint = (canvasX, canvasY) => {
+        // 도면 이미지는 contain으로 center에 위치하므로 실제 이미지 영역 계산 필요
+        // 간단히 캔버스 중앙 80% 영역으로 제한 (실제로는 이미지 크기에 따라 달라짐)
+        const margin = 10; // 10% 여백
+        return canvasX >= margin && canvasX <= (100 - margin) && 
+               canvasY >= margin && canvasY <= (100 - margin);
+    };
 
 
     // API로부터 알람 목록 로드
@@ -155,8 +417,25 @@ const MonitoringPage = () => {
     // 컴포넌트 마운트 시 데이터 로드
     useEffect(() => {
         loadAlarms();
-        // fetchRiskZoneData(); // 추후 필요시 활성화
-    }, [alertsPagination.page, alertsPagination.size, alertsPagination.hours]);
+        fetchAvailableBlueprints();
+    }, [alertsPagination.page, alertsPagination.size, alertsPagination.hours, fetchAvailableBlueprints]);
+
+    // 초기 도면 자동 선택 (첫 번째 도면)
+    useEffect(() => {
+        if (availableBlueprints.length > 0 && !currentBlueprint) {
+            const firstBlueprint = availableBlueprints[0];
+            selectBlueprint(firstBlueprint.id.toString());
+        }
+    }, [availableBlueprints, currentBlueprint, selectBlueprint]);
+
+    // 컴포넌트 언마운트 시 blob URL 정리
+    useEffect(() => {
+        return () => {
+            if (blueprintImage && blueprintImage.startsWith('blob:')) {
+                URL.revokeObjectURL(blueprintImage);
+            }
+        };
+    }, [blueprintImage]);
 
     // 필터 변경 핸들러
     const handleFilterChange = (filterType, value) => {
@@ -185,11 +464,21 @@ const MonitoringPage = () => {
         }
     };
 
-    // 필터된 작업자 목록
-    const filteredWorkers = workers.filter(worker => {
-        if (selectedFilter.attribute === 'all') return true;
-        return worker.status === selectedFilter.attribute;
-    });
+    // 필터된 작업자 목록 (GPS 좌표를 캔버스 좌표로 변환)
+    const filteredWorkers = workers
+        .filter(worker => {
+            if (selectedFilter.attribute === 'all') return true;
+            return worker.status === selectedFilter.attribute;
+        })
+        .map(worker => {
+            // GPS 좌표를 캔버스 좌표로 변환
+            const canvasPosition = convertGPSToCanvas(worker.latitude, worker.longitude);
+            return {
+                ...worker,
+                x: canvasPosition.x,
+                y: canvasPosition.y
+            };
+        });
 
     return (
         <div className={styles.page}>
@@ -239,10 +528,44 @@ const MonitoringPage = () => {
             <div className={styles.contentSection}>
                 {/* 좌측: 도면 섹션 */}
                 <section className={styles.mapSection}>
-                    <h2 className={styles.mapTitle}>현장 도면 - 실시간 위치</h2>
+                    <div className={styles.mapHeader}>
+                        <h2 className={styles.mapTitle}>현장 도면 - 실시간 위치</h2>
+                        <select
+                            className={styles.blueprintSelect}
+                            value={currentBlueprint?.id || ''}
+                            onChange={(e) => selectBlueprint(e.target.value)}
+                        >
+                            <option value="">도면 선택</option>
+                            {availableBlueprints.map(blueprint => (
+                                <option key={blueprint.id} value={blueprint.id}>
+                                    {blueprint.name && blueprint.name.trim() ? 
+                                        `${blueprint.name} (${blueprint.floor}층)` : 
+                                        `${blueprint.floor}층 도면`
+                                    }
+                                </option>
+                            ))}
+                        </select>
+                    </div>
 
                     <div className={styles.mapContainer} ref={mapRef}>
-                        <div className={styles.mapCanvas}>
+                        <div 
+                            className={styles.mapCanvas}
+                            style={{
+                                backgroundImage: blueprintImage ? `url(${blueprintImage})` : 'none',
+                                backgroundSize: 'contain',
+                                backgroundRepeat: 'no-repeat',
+                                backgroundPosition: 'center'
+                            }}
+                        >
+                            {/* 도면이 없는 경우 안내 메시지 */}
+                            {!blueprintImage && (
+                                <div className={styles.noBlueprintMessage}>
+                                    {currentBlueprint ? 
+                                        `${currentBlueprint.name || `${currentBlueprint.floor}층`} 도면을 로드하는 중...` : 
+                                        '도면을 선택해주세요'
+                                    }
+                                </div>
+                            )}
                             {/* 위험구역 렌더링 */}
                             {dangerZones.map(zone => (
                                 <div

--- a/frontend/src/pages/RiskZonePage.js
+++ b/frontend/src/pages/RiskZonePage.js
@@ -1,46 +1,32 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import styles from '../styles/RiskZone.module.css';
 import { riskZoneAPI, blueprintAPI } from '../api/api';
 
-/**
- * 위험구역 설정 및 관리 페이지
- * 
- * TODO: 향후 구현 예정
- * - GPS 좌표 매핑 시스템 구현
- * - 실제 좌표 기반 위험구역 표시
- */
-
 const RiskZonePage = () => {
     const canvasRef = useRef(null);
-    const [selectedFloor, setSelectedFloor] = useState('1F');
-    const [isSelecting, setIsSelecting] = useState(false);
-    const [dragStart, setDragStart] = useState(null);
-    const [dragEnd, setDragEnd] = useState(null);
-    const [selectedZone, setSelectedZone] = useState(null);
 
-    // 선택된 위치 정보
-    const [locationInfo, setLocationInfo] = useState({
-        x: '',
-        y: '',
-        name: '',
-        width: '',
-        height: ''
-    });
-
-    // 현재 페이지 상태
+    // 페이지네이션 상태
     const [currentPage, setCurrentPage] = useState(0);
     const [pageSize] = useState(5);
     const [totalPages, setTotalPages] = useState(1);
 
-    // 위험구역 목록 데이터
+    // 위험구역 관련 상태
     const [riskZones, setRiskZones] = useState([]);
-
-    // 캔버스에 그려진 위험구역들
-    const [canvasZones, setCanvasZones] = useState([]);
+    const [isSelecting, setIsSelecting] = useState(false);
+    const [clickedPoint, setClickedPoint] = useState(null);
+    const [riskZoneForm, setRiskZoneForm] = useState({
+        name: '',
+        width: '3.0',
+        height: '3.0',
+        gpsLat: 0,
+        gpsLon: 0
+    });
 
     // 도면 관련 상태
     const [currentBlueprint, setCurrentBlueprint] = useState(null);
     const [blueprintImage, setBlueprintImage] = useState(null);
+    const [availableBlueprintsForSelection, setAvailableBlueprintsForSelection] = useState([]);
+    const [availableBlueprints, setAvailableBlueprints] = useState([]);
 
     // 수정 모달 상태
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -53,7 +39,6 @@ const RiskZonePage = () => {
         height: '',
         name: ''
     });
-    const [availableBlueprints, setAvailableBlueprints] = useState([]);
 
     // 위험구역 데이터 조회
     const fetchRiskZones = useCallback(async () => {
@@ -65,47 +50,35 @@ const RiskZonePage = () => {
 
             const data = response.data || response;
             const zones = data.content || [];
-            
+
+            // Helper function to format zone
+            const formatZone = (zone, floorInfo = null) => ({
+                id: zone.id,
+                floor: floorInfo ? `${floorInfo}F` : `${zone.blueprintId}F`,
+                name: zone.name || `위험구역 ${zone.id}`,
+                latitude: zone.latitude,
+                longitude: zone.longitude,
+                width: `${zone.width} m`,
+                height: `${zone.height} m`,
+                blueprintId: zone.blueprintId,
+                originalWidth: zone.width,
+                originalHeight: zone.height
+            });
+
             // Blueprint 정보 조회해서 floor 매핑
             const formattedZones = await Promise.all(
                 zones.map(async (zone) => {
                     try {
-                        // blueprintId로 Blueprint 정보 조회
                         const blueprintResponse = await blueprintAPI.getBlueprint(zone.blueprintId);
                         const blueprint = blueprintResponse.data || blueprintResponse;
-                        
-                        return {
-                            id: zone.id,
-                            floor: `${blueprint.floor}F`,
-                            name: zone.name || `위험구역 ${zone.id}`,
-                            latitude: zone.latitude,
-                            longitude: zone.longitude,
-                            width: `${zone.width} m`,
-                            height: `${zone.height} m`,
-                            // 원본 데이터도 보관
-                            blueprintId: zone.blueprintId,
-                            originalWidth: zone.width,
-                            originalHeight: zone.height
-                        };
+                        return formatZone(zone, blueprint.floor);
                     } catch (error) {
                         console.error(`Blueprint ${zone.blueprintId} 조회 실패:`, error);
-                        // Blueprint 조회 실패 시 기본값 사용
-                        return {
-                            id: zone.id,
-                            floor: `${zone.blueprintId}F`, // fallback
-                            name: zone.name || `위험구역 ${zone.id}`,
-                            latitude: zone.latitude,
-                            longitude: zone.longitude,
-                            width: `${zone.width} m`,
-                            height: `${zone.height} m`,
-                            blueprintId: zone.blueprintId,
-                            originalWidth: zone.width,
-                            originalHeight: zone.height
-                        };
+                        return formatZone(zone);
                     }
                 })
             );
-            
+
             setRiskZones(formattedZones);
             setTotalPages(data.totalPages || 1);
 
@@ -113,43 +86,48 @@ const RiskZonePage = () => {
             console.error('위험구역 데이터 조회 실패:', error);
             setRiskZones([]);
             setTotalPages(1);
+            alert('위험구역 데이터를 불러오는데 실패했습니다.');
         }
     }, [currentPage, pageSize]);
 
-    // 사용 가능한 도면 목록 조회 (수정 모달용)
+    // 사용 가능한 도면 목록 조회
     const fetchAvailableBlueprints = useCallback(async () => {
         try {
             const response = await blueprintAPI.getBlueprints({
                 page: 0,
-                size: 50 // 충분히 많이 가져오기
+                size: 50
             });
 
-            const data = response.data || response;
-            setAvailableBlueprints(data.content || []);
+            if (response.status === 'success' && response.data) {
+                const data = response.data;
+                const blueprints = data.content || [];
+                setAvailableBlueprints(blueprints);
+                setAvailableBlueprintsForSelection(blueprints);
+            } else {
+                setAvailableBlueprints([]);
+                setAvailableBlueprintsForSelection([]);
+            }
         } catch (error) {
             console.error('도면 목록 조회 실패:', error);
             setAvailableBlueprints([]);
+            setAvailableBlueprintsForSelection([]);
         }
     }, []);
 
-    // 도면 데이터 조회
-    const fetchBlueprint = useCallback(async () => {
-        try {
-            const floorNumber = parseInt(selectedFloor.replace('F', '')); // "1F" -> 1
-            const response = await blueprintAPI.getBlueprints({
-                page: 0,
-                size: 1,
-                target: 'floor',
-                keyword: floorNumber.toString()
-            });
+    // 특정 Blueprint 선택 및 로드
+    const selectBlueprint = useCallback(async (blueprintId) => {
+        if (!blueprintId) {
+            setCurrentBlueprint(null);
+            setBlueprintImage(null);
+            return;
+        }
 
-            const data = response.data || response;
-            
-            if (data.content && data.content.length > 0) {
-                const blueprint = data.content[0];
+        try {
+            const parsedId = parseInt(blueprintId, 10);
+            const blueprint = availableBlueprintsForSelection.find(bp => bp.id === parsedId);
+            if (blueprint) {
                 setCurrentBlueprint(blueprint);
-                console.log(`${selectedFloor} 도면 로드됨 - ID: ${blueprint.id}, Floor: ${blueprint.floor}`);
-                
+
                 // 도면 이미지 Blob URL 생성 (인증 헤더 포함)
                 try {
                     const blobUrl = await blueprintAPI.getBlueprintImageBlob(blueprint.id);
@@ -159,173 +137,223 @@ const RiskZonePage = () => {
                     setBlueprintImage(null);
                 }
             } else {
-                // 해당 층의 도면이 없는 경우
-                console.warn(`${selectedFloor} 층의 도면을 찾을 수 없습니다.`);
+                console.warn(`Blueprint ID ${blueprintId}를 찾을 수 없습니다.`);
                 setCurrentBlueprint(null);
                 setBlueprintImage(null);
             }
         } catch (error) {
-            console.error('도면 데이터 조회 실패:', error);
+            console.error('도면 선택 실패:', error);
             setCurrentBlueprint(null);
             setBlueprintImage(null);
+            alert('도면을 선택하는데 실패했습니다.');
         }
-    }, [selectedFloor]);
+    }, [availableBlueprintsForSelection]);
 
-    // 캔버스 마우스 이벤트 핸들러
-    const handleMouseDown = (e) => {
-        if (!isSelecting) return;
 
-        const rect = canvasRef.current.getBoundingClientRect();
-        const x = ((e.clientX - rect.left) / rect.width) * 100;
-        const y = ((e.clientY - rect.top) / rect.height) * 100;
 
-        setDragStart({ x, y });
-        setDragEnd({ x, y });
-    };
+    // Bilinear interpolation 헬퍼 함수
+    const bilinearInterpolation = useCallback((u, v, corners) => {
+        const { topLeft, topRight, bottomLeft, bottomRight } = corners;
+        
+        const lat = (1-u)*(1-v)*topLeft.lat + u*(1-v)*topRight.lat +
+                   (1-u)*v*bottomLeft.lat + u*v*bottomRight.lat;
+        const lon = (1-u)*(1-v)*topLeft.lon + u*(1-v)*topRight.lon +
+                   (1-u)*v*bottomLeft.lon + u*v*bottomRight.lon;
+        
+        return { lat, lon };
+    }, []);
 
-    const handleMouseMove = (e) => {
-        if (!isSelecting || !dragStart) return;
-
-        const rect = canvasRef.current.getBoundingClientRect();
-        const x = ((e.clientX - rect.left) / rect.width) * 100;
-        const y = ((e.clientY - rect.top) / rect.height) * 100;
-
-        setDragEnd({ x, y });
-    };
-
-    const handleMouseUp = (e) => {
-        if (!isSelecting || !dragStart || !dragEnd) return;
-
-        const width = Math.abs(dragEnd.x - dragStart.x);
-        const height = Math.abs(dragEnd.y - dragStart.y);
-
-        if (width > 2 && height > 2) { // 최소 크기 체크
-            const newZone = {
-                id: Date.now(),
-                x: Math.min(dragStart.x, dragEnd.x),
-                y: Math.min(dragStart.y, dragEnd.y),
-                width: width,
-                height: height
-            };
-
-            setCanvasZones(prev => [...prev, newZone]);
-            setSelectedZone(newZone);
-
-            // 위치 정보 업데이트 (GPS 좌표 매핑 구현 후 수정 필요)
-            setLocationInfo({
-                x: newZone.x.toFixed(2),
-                y: newZone.y.toFixed(2),
-                name: '',
-                width: newZone.width.toFixed(1),
-                height: newZone.height.toFixed(1)
-            });
+    // 캔버스 좌표를 GPS 좌표로 변환
+    const convertCanvasToGPS = useCallback((canvasX, canvasY) => {
+        if (!currentBlueprint?.topLeft || !currentBlueprint?.topRight ||
+            !currentBlueprint?.bottomLeft || !currentBlueprint?.bottomRight) {
+            console.warn('Blueprint 좌표 정보가 없습니다');
+            return { lat: 0, lon: 0 };
         }
 
-        setDragStart(null);
-        setDragEnd(null);
+        const u = canvasX / 100;
+        const v = canvasY / 100;
+        
+        return bilinearInterpolation(u, v, currentBlueprint);
+    }, [currentBlueprint, bilinearInterpolation]);
+
+
+    // 도면 이미지 영역 내부인지 확인
+    const isInsideBlueprint = useCallback((canvasX, canvasY) => {
+        const margin = 10;
+        return canvasX >= margin && canvasX <= (100 - margin) &&
+               canvasY >= margin && canvasY <= (100 - margin);
+    }, []);
+
+    // 캔버스 클릭 이벤트 핸들러
+    const handleCanvasClick = useCallback((e) => {
+        if (!isSelecting || !currentBlueprint) {
+            return;
+        }
+
+        const rect = canvasRef.current.getBoundingClientRect();
+        const canvasX = ((e.clientX - rect.left) / rect.width) * 100;
+        const canvasY = ((e.clientY - rect.top) / rect.height) * 100;
+
+        if (!isInsideBlueprint(canvasX, canvasY)) {
+            alert('도면 영역 내에서만 위치를 선택할 수 있습니다.');
+            return;
+        }
+
+        const gpsCoord = convertCanvasToGPS(canvasX, canvasY);
+
+        setClickedPoint({ x: canvasX, y: canvasY });
+        setRiskZoneForm(prevForm => ({
+            ...prevForm,
+            gpsLat: gpsCoord.lat,
+            gpsLon: gpsCoord.lon
+        }));
+
         setIsSelecting(false);
-    };
+    }, [isSelecting, currentBlueprint, isInsideBlueprint, convertCanvasToGPS]);
 
     // Select Location 버튼 클릭
-    const handleSelectLocation = () => {
+    const handleSelectLocation = useCallback(() => {
         setIsSelecting(!isSelecting);
-        setDragStart(null);
-        setDragEnd(null);
-    };
+        setClickedPoint(null);
+    }, [isSelecting]);
 
-    // 위험구역 클릭
-    const handleZoneClick = (zone) => {
-        setSelectedZone(zone);
-        setLocationInfo({
-            x: zone.x.toFixed(2),
-            y: zone.y.toFixed(2),
-            name: zone.name || '',
-            width: zone.width.toFixed(1),
-            height: zone.height.toFixed(1)
-        });
-    };
+    // 미터를 캔버스 크기로 변환 (미리보기용)
+    const convertMetersToCanvas = useCallback((widthMeters, heightMeters) => {
+        if (!currentBlueprint?.width || !currentBlueprint?.height) {
+            return { width: 0, height: 0 };
+        }
 
-    // 위치 정보 저장 (위험구역 등록)
-    const handleSaveLocation = async () => {
-        if (!selectedZone) {
-            alert('구역을 선택해주세요.');
+        let realBuildingWidth, realBuildingHeight;
+        
+        if (currentBlueprint.width > 100) {
+            realBuildingWidth = currentBlueprint.width * 0.05;
+            realBuildingHeight = currentBlueprint.height * 0.05;
+        } else {
+            realBuildingWidth = currentBlueprint.width;
+            realBuildingHeight = currentBlueprint.height;
+        }
+
+        const widthRatio = (widthMeters / realBuildingWidth);
+        const heightRatio = (heightMeters / realBuildingHeight);
+        
+        const canvasWidth = Math.min(widthRatio * 80, 30); // 최대 30%로 제한
+        const canvasHeight = Math.min(heightRatio * 80, 30); // 최대 30%로 제한
+        
+        return { width: canvasWidth, height: canvasHeight };
+    }, [currentBlueprint]);
+
+    // 위험구역 미리보기 박스 계산
+    const getPreviewBox = useMemo(() => {
+        if (!clickedPoint || !riskZoneForm.width || !riskZoneForm.height) {
+            return null;
+        }
+
+        const widthNum = parseFloat(riskZoneForm.width);
+        const heightNum = parseFloat(riskZoneForm.height);
+        
+        if (isNaN(widthNum) || isNaN(heightNum) || widthNum <= 0 || heightNum <= 0) {
+            return null;
+        }
+
+        const boxSize = convertMetersToCanvas(widthNum, heightNum);
+        
+        return {
+            left: `${clickedPoint.x - boxSize.width / 2}%`,
+            top: `${clickedPoint.y - boxSize.height / 2}%`,
+            width: `${boxSize.width}%`,
+            height: `${boxSize.height}%`
+        };
+    }, [clickedPoint, riskZoneForm.width, riskZoneForm.height, convertMetersToCanvas]);
+
+
+    // 위험구역 등록
+    const handleCreateRiskZone = async () => {
+        if (!clickedPoint) {
+            alert('위치를 먼저 클릭해주세요.');
             return;
         }
 
         if (!currentBlueprint || !currentBlueprint.id) {
-            alert('도면 정보가 없습니다. 층수를 선택해주세요.');
+            alert('도면을 선택해주세요.');
+            return;
+        }
+
+        if (!riskZoneForm.name.trim()) {
+            alert('위험구역 이름을 입력해주세요.');
+            return;
+        }
+
+        if (!riskZoneForm.width || !riskZoneForm.height ||
+            parseFloat(riskZoneForm.width) <= 0 || parseFloat(riskZoneForm.height) <= 0) {
+            alert('유효한 크기를 입력해주세요.');
             return;
         }
 
         try {
-            console.log('locationInfo:', locationInfo);
-            console.log('locationInfo.name:', locationInfo.name);
-            
-            // 캔버스 좌표를 실제 GPS 좌표로 변환 (여기서는 임시로 그대로 사용)
             const riskZoneData = {
                 blueprintId: currentBlueprint.id,
-                latitude: parseFloat(locationInfo.x) || selectedZone.x,
-                longitude: parseFloat(locationInfo.y) || selectedZone.y,
-                width: parseFloat(locationInfo.width) || selectedZone.width,
-                height: parseFloat(locationInfo.height) || selectedZone.height,
-                name: locationInfo.name.trim() || `위험구역 ${Date.now()}`
+                latitude: riskZoneForm.gpsLat,
+                longitude: riskZoneForm.gpsLon,
+                width: parseFloat(riskZoneForm.width),
+                height: parseFloat(riskZoneForm.height),
+                name: riskZoneForm.name.trim()
             };
 
             console.log('위험구역 등록 데이터:', riskZoneData);
             const response = await riskZoneAPI.createRiskZone(riskZoneData);
             console.log('위험구역 등록 완료:', response);
-            
+
             alert('위험구역이 성공적으로 등록되었습니다.');
-            
-            // 캔버스에서 임시 구역 제거
-            setCanvasZones(prev => prev.filter(zone => zone.id !== selectedZone.id));
-            setSelectedZone(null);
-            setLocationInfo({
-                x: '',
-                y: '',
+
+            // 폼 초기화
+            setClickedPoint(null);
+            setRiskZoneForm({
                 name: '',
-                width: '',
-                height: ''
+                width: '3.0',
+                height: '3.0',
+                gpsLat: 0,
+                gpsLon: 0
             });
-            
+
             // 목록 새로고침
             await fetchRiskZones();
 
         } catch (error) {
-            console.error('위험구역 저장 실패:', error);
-            alert(`저장에 실패했습니다: ${error.message}`);
+            console.error('위험구역 등록 실패:', error);
+            alert(`등록에 실패했습니다: ${error.message}`);
         }
     };
 
     // 위험구역 수정 모달 열기
     const handleEdit = async (zone) => {
         setEditingZone(zone);
-        
+
         // blueprintId로 해당 도면 정보 조회해서 floor 가져오기
         try {
             const blueprintResponse = await blueprintAPI.getBlueprint(zone.blueprintId);
             const blueprint = blueprintResponse.data || blueprintResponse;
-            
+
             setEditFormData({
                 floor: blueprint.floor || 1,
-                latitude: zone.latitude || 0,
-                longitude: zone.longitude || 0,
-                width: zone.originalWidth || parseFloat(zone.width) || 0,
-                height: zone.originalHeight || parseFloat(zone.height) || 0,
+                latitude: String(zone.latitude || 0),
+                longitude: String(zone.longitude || 0),
+                width: String(zone.originalWidth || parseFloat(zone.width) || 0),
+                height: String(zone.originalHeight || parseFloat(zone.height) || 0),
                 name: zone.name || ''
             });
         } catch (error) {
             console.error('도면 정보 조회 실패:', error);
             setEditFormData({
                 floor: 1,
-                latitude: zone.latitude || 0,
-                longitude: zone.longitude || 0,
-                width: zone.originalWidth || parseFloat(zone.width) || 0,
-                height: zone.originalHeight || parseFloat(zone.height) || 0,
+                latitude: String(zone.latitude || 0),
+                longitude: String(zone.longitude || 0),
+                width: String(zone.originalWidth || parseFloat(zone.width) || 0),
+                height: String(zone.originalHeight || parseFloat(zone.height) || 0),
                 name: zone.name || ''
             });
         }
-        
+
         setIsEditModalOpen(true);
     };
 
@@ -344,12 +372,12 @@ const RiskZonePage = () => {
     };
 
     // 수정 폼 데이터 변경
-    const handleEditFormChange = (field, value) => {
-        setEditFormData(prev => ({
-            ...prev,
+    const handleEditFormChange = useCallback((field, value) => {
+        setEditFormData(prevData => ({
+            ...prevData,
             [field]: value
         }));
-    };
+    }, []);
 
     // 위험구역 수정 저장
     const handleSaveEdit = async () => {
@@ -373,13 +401,13 @@ const RiskZonePage = () => {
             };
 
             await riskZoneAPI.updateRiskZone(editingZone.id, updateData);
-            
+
             alert('위험구역이 성공적으로 수정되었습니다.');
             handleCloseEditModal();
-            
+
             // 목록 새로고침
             await fetchRiskZones();
-            
+
         } catch (error) {
             console.error('위험구역 수정 실패:', error);
             alert(`수정에 실패했습니다: ${error.message}`);
@@ -395,7 +423,7 @@ const RiskZonePage = () => {
         try {
             await riskZoneAPI.deleteRiskZone(zoneId);
             alert('위험구역이 성공적으로 삭제되었습니다.');
-            
+
             // 목록 새로고침
             await fetchRiskZones();
         } catch (error) {
@@ -404,40 +432,54 @@ const RiskZonePage = () => {
         }
     };
 
-    // 드래그 영역 계산
-    const getDragArea = () => {
-        if (!dragStart || !dragEnd) return null;
-
-        return {
-            left: `${Math.min(dragStart.x, dragEnd.x)}%`,
-            top: `${Math.min(dragStart.y, dragEnd.y)}%`,
-            width: `${Math.abs(dragEnd.x - dragStart.x)}%`,
-            height: `${Math.abs(dragEnd.y - dragStart.y)}%`
-        };
-    };
 
     // 컴포넌트 마운트 시 위험구역 목록과 도면 목록 조회
     useEffect(() => {
-        fetchRiskZones();
-        fetchAvailableBlueprints();
+        const loadData = async () => {
+            try {
+                await Promise.all([
+                    fetchRiskZones(),
+                    fetchAvailableBlueprints()
+                ]);
+            } catch (error) {
+                console.error('데이터 로드 실패:', error);
+            }
+        };
+        loadData().catch(error => {
+            console.error('데이터 로드 실패:', error);
+        });
     }, [currentPage, fetchRiskZones, fetchAvailableBlueprints]);
 
-    // 초기 로드 + 층 변경 시 도면 조회
+    // 초기 도면 자동 선택 (첫 번째 도면)
     useEffect(() => {
-        fetchBlueprint();
-    }, [selectedFloor, fetchBlueprint]);
+        const selectFirstBlueprint = async () => {
+            if (availableBlueprintsForSelection.length > 0 && !currentBlueprint) {
+                const firstBlueprint = availableBlueprintsForSelection[0];
+                if (firstBlueprint && firstBlueprint.id) {
+                    try {
+                        await selectBlueprint(String(firstBlueprint.id));
+                    } catch (error) {
+                        console.error('초기 도면 선택 실패:', error);
+                    }
+                }
+            }
+        };
+        selectFirstBlueprint().catch(error => {
+            console.error('초기 도면 선택 실패:', error);
+        });
+    }, [availableBlueprintsForSelection, currentBlueprint, selectBlueprint]);
 
     // 컴포넌트 언마운트 시 blob URL 정리
     useEffect(() => {
         return () => {
-            if (blueprintImage && blueprintImage.startsWith('blob:')) {
+            if (blueprintImage && typeof blueprintImage === 'string' && blueprintImage.startsWith('blob:')) {
                 URL.revokeObjectURL(blueprintImage);
             }
         };
     }, [blueprintImage]);
 
-    // 현재 페이지 데이터 (API에서 이미 페이지네이션 적용됨)
-    const currentZones = riskZones;
+    // 현재 페이지 데이터
+    const currentZones = useMemo(() => riskZones, [riskZones]);
 
     return (
         <div className={styles.page}>
@@ -454,25 +496,38 @@ const RiskZonePage = () => {
                         <h2 className={styles.sectionTitle}>위험 구역</h2>
                         <select
                             className={styles.floorSelect}
-                            value={selectedFloor}
-                            onChange={(e) => setSelectedFloor(e.target.value)}
+                            value={currentBlueprint?.id ? String(currentBlueprint.id) : ''}
+                            onChange={(e) => {
+                                const value = e.target.value;
+                                if (value && value !== '') {
+                                    selectBlueprint(value).catch(error => {
+                                        console.error('도면 선택 실패:', error);
+                                    });
+                                } else {
+                                    selectBlueprint('').catch(error => {
+                                        console.error('도면 선택 실패:', error);
+                                    });
+                                }
+                            }}
                         >
-                            <option value="1F">1F</option>
-                            <option value="2F">2F</option>
-                            <option value="3F">3F</option>
-                            <option value="4F">4F</option>
-                            <option value="5F">5F</option>
+                            <option value="">도면 선택</option>
+                            {availableBlueprintsForSelection.map(blueprint => (
+                                <option key={String(blueprint.id)} value={String(blueprint.id)}>
+                                    {blueprint.name && blueprint.name.trim() ?
+                                        `${blueprint.name} (${blueprint.floor}층)` :
+                                        `${blueprint.floor}층 도면`
+                                    }
+                                </option>
+                            ))}
                         </select>
                     </div>
 
                     <div
                         className={`${styles.canvasContainer} ${isSelecting ? styles.drawing : ''}`}
                         ref={canvasRef}
-                        onMouseDown={handleMouseDown}
-                        onMouseMove={handleMouseMove}
-                        onMouseUp={handleMouseUp}
+                        onClick={handleCanvasClick}
                     >
-                        <div 
+                        <div
                             className={styles.canvas}
                             style={{
                                 backgroundImage: blueprintImage ? `url(${blueprintImage})` : 'none',
@@ -484,47 +539,71 @@ const RiskZonePage = () => {
                             {/* 도면이 없는 경우 안내 메시지 */}
                             {!blueprintImage && (
                                 <div className={styles.noBlueprintMessage}>
-                                    {selectedFloor} 층의 도면이 없습니다
+                                    {currentBlueprint ?
+                                        `${currentBlueprint.name || `${currentBlueprint.floor}층`} 도면을 로드하는 중...` :
+                                        '도면을 선택해주세요'
+                                    }
                                 </div>
                             )}
-                            
-                            {/* 기존 위험구역들 */}
-                            {canvasZones.map(zone => (
-                                <div
-                                    key={zone.id}
-                                    className={`${styles.riskZone} ${selectedZone?.id === zone.id ? styles.selected : ''}`}
-                                    style={{
-                                        left: `${zone.x}%`,
-                                        top: `${zone.y}%`,
-                                        width: `${zone.width}%`,
-                                        height: `${zone.height}%`
-                                    }}
-                                    onClick={() => handleZoneClick(zone)}
-                                    title={zone.name || '위험구역'}
-                                />
-                            ))}
 
-                            {/* 드래그 중인 영역 */}
-                            {dragStart && dragEnd && (
+                            {/* 위험구역 미리보기 박스 */}
+                            {getPreviewBox && (
                                 <div
-                                    className={styles.dragArea}
-                                    style={getDragArea()}
+                                    className={styles.previewBox}
+                                    style={{
+                                        position: 'absolute',
+                                        left: getPreviewBox.left,
+                                        top: getPreviewBox.top,
+                                        width: getPreviewBox.width,
+                                        height: getPreviewBox.height,
+                                        border: '2px solid #ff4444',
+                                        backgroundColor: 'rgba(255, 68, 68, 0.3)',
+                                        pointerEvents: 'none',
+                                        borderRadius: '4px'
+                                    }}
                                 />
                             )}
+
+                            {/* 클릭한 지점 표시 */}
+                            {clickedPoint && (
+                                <div
+                                    className={styles.clickedPoint}
+                                    style={{
+                                        position: 'absolute',
+                                        left: `${clickedPoint.x}%`,
+                                        top: `${clickedPoint.y}%`,
+                                        width: '8px',
+                                        height: '8px',
+                                        backgroundColor: '#ff4444',
+                                        borderRadius: '50%',
+                                        transform: 'translate(-50%, -50%)',
+                                        pointerEvents: 'none',
+                                        border: '2px solid white',
+                                        boxShadow: '0 0 4px rgba(0,0,0,0.5)'
+                                    }}
+                                />
+                            )}
+
                         </div>
                     </div>
                 </div>
 
-                {/* 우측: Selected Location 정보 */}
+                {/* 우측: 위험구역 생성 폼 */}
                 <div className={styles.locationPanel}>
-                    <h3 className={styles.panelTitle}>Selected Location</h3>
+                    <h3 className={styles.panelTitle}>위험구역 생성</h3>
 
                     <div className={styles.coordinateInfo}>
                         <p className={styles.coordinateText}>
-                            위치: {locationInfo.x ? `X: ${locationInfo.x}, Y: ${locationInfo.y}` : '영역을 선택해주세요'}
+                            GPS 좌표: {clickedPoint ?
+                                `위도: ${riskZoneForm.gpsLat.toFixed(6)}, 경도: ${riskZoneForm.gpsLon.toFixed(6)}` :
+                                '위치를 클릭해주세요'
+                            }
                         </p>
                         <p className={styles.coordinateText}>
-                            층수: {selectedFloor} {currentBlueprint ? '' : '(도면 없음)'}
+                            도면: {currentBlueprint ?
+                                (currentBlueprint.name || `${currentBlueprint.floor}층 도면`) :
+                                '도면을 선택해주세요'
+                            }
                         </p>
                     </div>
 
@@ -533,8 +612,13 @@ const RiskZonePage = () => {
                         <input
                             type="text"
                             className={styles.formInput}
-                            value={locationInfo.name}
-                            onChange={(e) => setLocationInfo(prev => ({ ...prev, name: e.target.value }))}
+                            value={riskZoneForm.name}
+                            onChange={(e) => {
+                                setRiskZoneForm(prevForm => ({
+                                    ...prevForm,
+                                    name: e.target.value
+                                }));
+                            }}
                             placeholder="위험구역 이름을 입력하세요"
                         />
                     </div>
@@ -544,11 +628,16 @@ const RiskZonePage = () => {
                         <input
                             type="number"
                             step="0.1"
+                            min="0.1"
                             className={styles.formInput}
-                            value={locationInfo.width}
-                            onChange={(e) => setLocationInfo(prev => ({ ...prev, width: e.target.value }))}
+                            value={riskZoneForm.width}
+                            onChange={(e) => {
+                                setRiskZoneForm(prevForm => ({
+                                    ...prevForm,
+                                    width: e.target.value
+                                }));
+                            }}
                             placeholder="너비 (m)"
-                            disabled={!selectedZone}
                         />
                     </div>
 
@@ -557,11 +646,16 @@ const RiskZonePage = () => {
                         <input
                             type="number"
                             step="0.1"
+                            min="0.1"
                             className={styles.formInput}
-                            value={locationInfo.height}
-                            onChange={(e) => setLocationInfo(prev => ({ ...prev, height: e.target.value }))}
+                            value={riskZoneForm.height}
+                            onChange={(e) => {
+                                setRiskZoneForm(prevForm => ({
+                                    ...prevForm,
+                                    height: e.target.value
+                                }));
+                            }}
                             placeholder="높이 (m)"
-                            disabled={!selectedZone}
                         />
                     </div>
 
@@ -569,13 +663,14 @@ const RiskZonePage = () => {
                         <button
                             className={`${styles.selectLocationBtn} ${isSelecting ? styles.active : ''}`}
                             onClick={handleSelectLocation}
+                            disabled={!currentBlueprint}
                         >
-                            Select Location
+                            {isSelecting ? '위치 선택 중...' : '위치 선택'}
                         </button>
                         <button
                             className={styles.saveLocationBtn}
-                            onClick={handleSaveLocation}
-                            disabled={!selectedZone}
+                            onClick={handleCreateRiskZone}
+                            disabled={!clickedPoint || !riskZoneForm.name.trim() || !riskZoneForm.width || !riskZoneForm.height}
                         >
                             위험구역 등록
                         </button>
@@ -675,21 +770,21 @@ const RiskZonePage = () => {
                     <div className={styles.modal}>
                         <div className={styles.modalHeader}>
                             <h3 className={styles.modalTitle}>위험구역 수정</h3>
-                            <button 
+                            <button
                                 className={styles.modalCloseBtn}
                                 onClick={handleCloseEditModal}
                             >
                                 ×
                             </button>
                         </div>
-                        
+
                         <div className={styles.modalBody}>
                             <div className={styles.formGroup}>
                                 <label className={styles.formLabel}>층수</label>
                                 <select
                                     className={styles.formInput}
                                     value={editFormData.floor}
-                                    onChange={(e) => handleEditFormChange('floor', parseInt(e.target.value))}
+                                    onChange={(e) => handleEditFormChange('floor', parseInt(e.target.value, 10))}
                                 >
                                     {availableBlueprints.map(blueprint => (
                                         <option key={blueprint.id} value={blueprint.floor}>
@@ -760,13 +855,13 @@ const RiskZonePage = () => {
                         </div>
 
                         <div className={styles.modalFooter}>
-                            <button 
+                            <button
                                 className={styles.modalCancelBtn}
                                 onClick={handleCloseEditModal}
                             >
                                 취소
                             </button>
-                            <button 
+                            <button
                                 className={styles.modalSaveBtn}
                                 onClick={handleSaveEdit}
                             >

--- a/frontend/src/styles/AlarmModal.module.css
+++ b/frontend/src/styles/AlarmModal.module.css
@@ -1,0 +1,307 @@
+/* 모달 오버레이 */
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 20px;
+}
+
+/* 모달 컨텐츠 */
+.modalContent {
+    background: white;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 600px;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+/* 모달 헤더 */
+.modalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 20px 16px 20px;
+    border-bottom: 1px solid #E5E7EB;
+}
+
+.headerLeft {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.modalTitle {
+    font-size: 20px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+/* 시간 선택 드롭다운 */
+.hoursSelect {
+    padding: 6px 12px;
+    border: 1px solid #D1D5DB;
+    border-radius: 6px;
+    background: white;
+    color: #374151;
+    font-size: 14px;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+}
+
+.hoursSelect:hover {
+    border-color: #9CA3AF;
+}
+
+.hoursSelect:focus {
+    outline: none;
+    border-color: #3B82F6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.closeButton {
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: #F3F4F6;
+    border-radius: 6px;
+    font-size: 24px;
+    color: #6B7280;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.closeButton:hover {
+    background: #E5E7EB;
+    color: #374151;
+}
+
+/* 모달 바디 */
+.modalBody {
+    padding: 20px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+/* 알림 목록 */
+.alarmList {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 0 16px 20px 16px;
+}
+
+.alarmItem {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 12px 24px 12px 12px;
+    border-radius: 8px;
+    background: #FEF3C7;
+    border-left: 4px solid #F59E0B;
+    transition: all 0.2s ease;
+}
+
+.alarmItem:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.alarmItem.danger {
+    background: #FEE2E2;
+    border-left-color: #EF4444;
+}
+
+.alarmItem.health {
+    background: #EFF6FF;
+    border-left-color: #3B82F6;
+}
+
+.alarmIcon {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 600;
+    color: white;
+    flex-shrink: 0;
+}
+
+.alarmIcon.warning {
+    background: #F59E0B;
+}
+
+.alarmIcon.danger {
+    background: #EF4444;
+}
+
+.alarmIcon.health {
+    background: #3B82F6;
+}
+
+.alarmContent {
+    flex: 1;
+    min-width: 0;
+}
+
+.alarmTitle {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0 0 4px 0;
+}
+
+.alarmDesc {
+    font-size: 14px;
+    color: #6B7280;
+    margin: 0 0 4px 0;
+    line-height: 1.4;
+}
+
+.alarmMeta {
+    font-size: 12px;
+    color: #9CA3AF;
+    margin: 0;
+}
+
+.alarmTime {
+    font-size: 12px;
+    color: #9CA3AF;
+    flex-shrink: 0;
+    align-self: flex-start;
+}
+
+/* 페이지네이션 */
+.pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 0;
+    border-top: 1px solid #E5E7EB;
+}
+
+.pageButton {
+    padding: 8px 16px;
+    border: 1px solid #D1D5DB;
+    background: white;
+    color: #374151;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.pageButton:hover:not(:disabled) {
+    background: #F3F4F6;
+    border-color: #9CA3AF;
+}
+
+.pageButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.pageInfo {
+    font-size: 14px;
+    color: #6B7280;
+    text-align: center;
+}
+
+/* 상태 표시 */
+.loadingState,
+.emptyState {
+    text-align: center;
+    padding: 60px 20px;
+    color: #9CA3AF;
+    font-size: 16px;
+}
+
+.loadingState {
+    color: #6B7280;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+    .modalOverlay {
+        padding: 10px;
+    }
+
+    .modalContent {
+        max-height: 90vh;
+    }
+
+    .modalHeader {
+        padding: 20px 20px 16px 20px;
+    }
+
+    .modalBody {
+        padding: 20px;
+    }
+
+    .modalTitle {
+        font-size: 18px;
+    }
+
+    .alarmItem {
+        padding: 12px;
+        gap: 12px;
+    }
+
+    .alarmIcon {
+        width: 28px;
+        height: 28px;
+        font-size: 14px;
+    }
+
+    .alarmTitle {
+        font-size: 15px;
+    }
+
+    .alarmDesc {
+        font-size: 13px;
+    }
+
+    .pagination {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .pageInfo {
+        order: -1;
+    }
+}
+
+@media (max-width: 480px) {
+    .modalContent {
+        margin: 0;
+        border-radius: 0;
+        max-height: 100vh;
+    }
+
+    .alarmItem {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .alarmTime {
+        align-self: flex-end;
+        margin-top: 8px;
+    }
+}

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -171,7 +171,7 @@
 /* 하단 위젯 그리드 */
 .widgetsSection {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: 1.5fr 1fr 1fr 1fr; /* 실시간 알림은 1.5배, 나머지는 1배 */
     gap: 24px;
 }
 
@@ -191,6 +191,41 @@
     font-weight: 600;
     color: #1F2937;
     margin: 0 0 20px 0;
+}
+
+/* 위젯 헤더 (제목 + 버튼) */
+.widgetHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.widgetHeader .widgetTitle {
+    margin: 0;
+}
+
+/* 더보기 버튼 */
+.moreButton {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    border: 2px solid #E5E7EB;
+    background: #F9FAFB;
+    color: #6B7280;
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.moreButton:hover {
+    border-color: #3B82F6;
+    background: #EFF6FF;
+    color: #3B82F6;
 }
 
 /* 실시간 위험 알림 위젯 */
@@ -220,6 +255,11 @@
     border-left-color: #EF4444;
 }
 
+.alertItem.health {
+    background: #EFF6FF;
+    border-left-color: #3B82F6;
+}
+
 .alertIcon {
     width: 24px;
     height: 24px;
@@ -239,6 +279,10 @@
 
 .alertIcon.danger {
     background: #EF4444;
+}
+
+.alertIcon.health {
+    background: #3B82F6;
 }
 
 .alertContent {

--- a/frontend/src/styles/Monitoring.module.css
+++ b/frontend/src/styles/Monitoring.module.css
@@ -105,11 +105,30 @@
     border: 1px solid #E5E7EB;
 }
 
+.mapHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
 .mapTitle {
     font-size: 18px;
     font-weight: 600;
     color: #1F2937;
-    margin: 0 0 24px 0;
+    margin: 0;
+}
+
+.blueprintSelect {
+    min-width: 200px;
+    padding: 8px 32px 8px 12px;
+    border: 1px solid #D1D5DB;
+    border-radius: 6px;
+    background: white url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e") no-repeat right 8px center / 12px;
+    font-size: 14px;
+    color: #1F2937;
+    cursor: pointer;
+    appearance: none;
 }
 
 /* 도면 컨테이너 */
@@ -127,6 +146,21 @@
     height: 100%;
     position: relative;
     cursor: crosshair;
+}
+
+.noBlueprintMessage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #9CA3AF;
+    font-size: 16px;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #E5E7EB;
 }
 
 /* 작업자 위치 점들 */

--- a/frontend/src/styles/Monitoring.module.css
+++ b/frontend/src/styles/Monitoring.module.css
@@ -83,18 +83,33 @@
     flex: 1;
 }
 
+/* 위젯 카드 공통 스타일 */
+.widgetCard {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+}
+
 /* 좌측: 도면 섹션 */
 .mapSection {
     display: flex;
     flex-direction: column;
     min-height: 600px;
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border: 1px solid #E5E7EB;
 }
 
 .mapTitle {
     font-size: 18px;
     font-weight: 600;
     color: #1F2937;
-    margin-bottom: 24px;
+    margin: 0 0 24px 0;
 }
 
 /* 도면 컨테이너 */
@@ -229,13 +244,18 @@
 
 /* 현장 현황 위젯 */
 .statusWidget {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border: 1px solid #E5E7EB;
 }
 
 .widgetTitle {
     font-size: 18px;
     font-weight: 600;
     color: #1F2937;
-    margin-bottom: 20px;
+    margin: 0 0 20px 0;
 }
 
 .statusSummary {
@@ -296,6 +316,11 @@
 /* 경고 알림 위젯 */
 .alertWidget {
     flex: 1;
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border: 1px solid #E5E7EB;
 }
 
 .alertList {
@@ -306,17 +331,12 @@
 
 .alertItem {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 12px;
-    padding: 16px;
+    padding: 12px;
     border-radius: 8px;
-    background: #F9FAFB;
-    border-left: 4px solid #D1D5DB;
-    transition: all 0.2s ease;
-}
-
-.alertItem:hover {
-    background: #F3F4F6;
+    background: #FEF3C7;
+    border-left: 4px solid #F59E0B;
 }
 
 .alertItem.danger {
@@ -324,27 +344,25 @@
     border-left-color: #EF4444;
 }
 
-.alertItem.warning {
-    background: #FEF3C7;
-    border-left-color: #F59E0B;
-}
-
 .alertIcon {
     width: 24px;
     height: 24px;
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 12px;
     font-weight: 600;
     color: white;
-    margin-top: 2px;
-}
-
-.alertIcon.danger {
-    background: #EF4444;
+    flex-shrink: 0;
 }
 
 .alertIcon.warning {
     background: #F59E0B;
+}
+
+.alertIcon.danger {
+    background: #EF4444;
 }
 
 .alertContent {
@@ -356,21 +374,19 @@
     font-size: 14px;
     font-weight: 600;
     color: #1F2937;
-    margin-bottom: 4px;
+    margin: 0 0 2px 0;
 }
 
 .alertDesc {
-    font-size: 13px;
+    font-size: 12px;
     color: #6B7280;
-    margin-bottom: 4px;
+    margin: 0;
 }
 
 .alertTime {
     font-size: 12px;
     color: #9CA3AF;
-    text-align: right;
     flex-shrink: 0;
-    margin-top: 2px;
 }
 
 /* 빈 상태 */
@@ -487,4 +503,49 @@
         text-align: center;
         gap: 8px;
     }
+}
+
+/* 위젯 헤더 (제목 + 버튼) */
+.widgetHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.widgetHeader .widgetTitle {
+    margin: 0;
+}
+
+/* 더보기 버튼 */
+.moreButton {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    border: 2px solid #E5E7EB;
+    background: #F9FAFB;
+    color: #6B7280;
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.moreButton:hover {
+    border-color: #3B82F6;
+    background: #EFF6FF;
+    color: #3B82F6;
+}
+
+/* 건강 위험 타입 스타일 */
+.alertItem.health {
+    background: #EFF6FF;
+    border-left-color: #3B82F6;
+}
+
+.alertIcon.health {
+    background: #3B82F6;
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---

## 변경 사항 
- 관리자 알림 기능
  - 우측 상단에 토스트로 알림이 약 3초간 표시되고, 추가적으로도 헤더에 알림 목록 표시
  (현재 웹소켓 기반으로 벨 아이콘에 알림 목록 생성 → 새로고침 시 웹소켓 알림은 사라짐)
  - Dashboard 실시간 위험 알림, Monitoring 실시간 경고 알림 → 웹소켓 + 목록 조회 방식으로 구현하여 새로고침해도 유지됨
  - 시간별 알림 조회 기능 추가

- 도면 기능
  - 도면 각 꼭짓점별 위도·경도 정보를 전달할 수 있도록 백엔드 구조 수정 (임베더블 클래스 기반)
  - 도면명 필드 추가
  - 위험구역 페이지에서 위도·경도 기반으로 도면 불러오기 구현
  - 캔버스 기반 width·height 계산 값이 정확하지 않은 문제 → 추후 수정 예정
  - 모니터링 페이지에 위험구역 표시 기능 추가 (위치 불일치 문제 수정 필요)

- 기타
  - 근로자 등록 모달의 비밀번호 검증 로직 수정 (특수문자 포함하도록 변경)
---
## 테스트 결과
<img width="2121" height="1322" alt="image" src="https://github.com/user-attachments/assets/2e25e042-4584-4ade-800b-70068bfbd05a" />
<img width="2152" height="1321" alt="image" src="https://github.com/user-attachments/assets/7e879dae-f9ad-47ee-8808-4c7a02b5d57a" />

---
## TODO
- 위험구역 캔버스 좌표 매핑 검증
- 알림 UI: 근로자 ID → 근로자 이름 표시
- API 명세서 수정
- 마스킹 처리