### PR TITLE
feat: 관리자 알람 UI에 근로자 이름 표시 및 마스킹 처리 완료

### DIFF
--- a/alarm/src/main/java/com/iroom/alarm/controller/AlarmController.java
+++ b/alarm/src/main/java/com/iroom/alarm/controller/AlarmController.java
@@ -1,6 +1,7 @@
 package com.iroom.alarm.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,7 +50,7 @@ public class AlarmController {
 	}
 
 	@GetMapping("/admins")
-	public ResponseEntity<ApiResponse<PagedResponse<Alarm>>> getAlarmsForAdmin(
+	public ResponseEntity<ApiResponse<PagedResponse<Map<String, Object>>>> getAlarmsForAdmin(
 		@RequestParam(defaultValue = "0") Integer page,
 		@RequestParam(defaultValue = "10") Integer size,
 		@RequestParam(defaultValue = "3") Integer hours) {
@@ -63,7 +64,7 @@ public class AlarmController {
 		if (hours > 168)
 			hours = 168; // 최대 1주일(7일)
 
-		PagedResponse<Alarm> response = alarmService.getAlarmsForAdmin(page, size, hours);
+		PagedResponse<Map<String, Object>> response = alarmService.getAlarmsForAdmin(page, size, hours);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/alarm/src/main/java/com/iroom/alarm/service/AlarmService.java
+++ b/alarm/src/main/java/com/iroom/alarm/service/AlarmService.java
@@ -1,6 +1,8 @@
 package com.iroom.alarm.service;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.iroom.alarm.config.StompHandler;
 import com.iroom.alarm.entity.Alarm;
+import com.iroom.alarm.entity.WorkerReadModel;
 import com.iroom.alarm.repository.AlarmRepository;
 import com.iroom.alarm.repository.WorkerReadModelRepository;
 import com.iroom.modulecommon.dto.event.AlarmEvent;
@@ -37,7 +40,10 @@ public class AlarmService {
 	// 외부 API 호출용
 	@PreAuthorize("hasAuthority('ROLE_PPE_SYSTEM')")
 	public SimpleResponse handleAlarmEventFromApi(AlarmEvent alarmEvent) {
-		processAlarmEvent(alarmEvent);
+		WorkerReadModel worker = workerReadModelRepository.findById(alarmEvent.workerId())
+			.orElseThrow(() -> new CustomException(ErrorCode.ALARM_WORKER_NOT_FOUND));
+
+		processAlarmEvent(alarmEvent, worker);
 		kafkaProducerService.publishMessage("PPE_VIOLATION", alarmEvent);
 
 		return new SimpleResponse("알람이 발행되었습니다.");
@@ -45,13 +51,13 @@ public class AlarmService {
 
 	// 내부 Kafka 이벤트 수신용
 	public void handleAlarmEvent(AlarmEvent alarmEvent) {
-		processAlarmEvent(alarmEvent);
+		WorkerReadModel worker = workerReadModelRepository.findById(alarmEvent.workerId())
+			.orElseThrow(() -> new CustomException(ErrorCode.ALARM_WORKER_NOT_FOUND));
+		processAlarmEvent(alarmEvent, worker);
 	}
 
 	// 실제 알림 처리 로직
-	private void processAlarmEvent(AlarmEvent alarmEvent) {
-		workerReadModelRepository.findById(alarmEvent.workerId())
-			.orElseThrow(() -> new CustomException(ErrorCode.ALARM_WORKER_NOT_FOUND));
+	private void processAlarmEvent(AlarmEvent alarmEvent, WorkerReadModel worker) {
 
 		Alarm alarm = Alarm.builder()
 			.workerId(alarmEvent.workerId())
@@ -67,8 +73,8 @@ public class AlarmService {
 		alarmRepository.save(alarm);
 
 		// WebSocket 실시간 전송
-		String adminMessage = String.format("[%s] %s (작업자 ID: %d)", alarmEvent.incidentType(),
-			alarmEvent.incidentDescription(), alarmEvent.workerId());
+		String adminMessage = String.format("[%s] %s (%s)", alarmEvent.incidentType(),
+			alarmEvent.incidentDescription(), worker.getName());
 		if (alarmEvent.workerImageUrl() != null) {
 			adminMessage += " (" + alarmEvent.workerImageUrl() + ")";
 		}
@@ -99,11 +105,29 @@ public class AlarmService {
 
 	// 관리자용 전체 알림 목록을 조회
 	@PreAuthorize("hasAnyAuthority('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_READER')")
-	public PagedResponse<Alarm> getAlarmsForAdmin(int page, int size, int hours) {
+	public PagedResponse<Map<String, Object>> getAlarmsForAdmin(int page, int size, int hours) {
 		Pageable pageable = PageRequest.of(page, size);
 		LocalDateTime time = LocalDateTime.now().minusHours(hours);
 		Page<Alarm> alarmPage = alarmRepository.findByOccurredAtAfterOrderByOccurredAtDesc(time, pageable);
 
-		return PagedResponse.of(alarmPage);
+		Page<Map<String, Object>> alarmWithWorkerPage = alarmPage.map(alarm -> {
+			WorkerReadModel worker = workerReadModelRepository.findById(alarm.getWorkerId()).orElse(null);
+			
+			Map<String, Object> alarmMap = new HashMap<>();
+			alarmMap.put("id", alarm.getId());
+			alarmMap.put("workerId", alarm.getWorkerId());
+			alarmMap.put("workerName", worker != null ? worker.getName() : "알 수 없음");
+			alarmMap.put("occurredAt", alarm.getOccurredAt());
+			alarmMap.put("incidentType", alarm.getIncidentType());
+			alarmMap.put("incidentId", alarm.getIncidentId());
+			alarmMap.put("latitude", alarm.getLatitude());
+			alarmMap.put("longitude", alarm.getLongitude());
+			alarmMap.put("incidentDescription", alarm.getIncidentDescription());
+			alarmMap.put("imageUrl", alarm.getImageUrl());
+			alarmMap.put("createdAt", alarm.getCreatedAt());
+			return alarmMap;
+		});
+
+		return PagedResponse.of(alarmWithWorkerPage);
 	}
 }

--- a/alarm/src/test/java/com/iroom/alarm/controller/AlarmControllerTest.java
+++ b/alarm/src/test/java/com/iroom/alarm/controller/AlarmControllerTest.java
@@ -6,7 +6,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -113,20 +115,22 @@ class AlarmControllerTest {
 	@DisplayName("관리자용 최근 3시간 알림 조회 성공")
 	void getAlarmsForAdminTest() throws Exception {
 		// given
-		List<Alarm> alarms = List.of(
-			Alarm.builder()
-				.workerId(2L)
-				.occurredAt(LocalDateTime.now())
-				.incidentType("HEALTH_EMERGENCY")
-				.incidentId(200L)
-				.incidentDescription("심박수 비정상 증가")
-				.latitude(37.5651)
-				.longitude(126.9895)
-				.build()
-		);
+		Map<String, Object> alarmMap = new HashMap<>();
+		alarmMap.put("id", 1L);
+		alarmMap.put("workerId", 2L);
+		alarmMap.put("workerName", "홍길동");
+		alarmMap.put("occurredAt", LocalDateTime.now());
+		alarmMap.put("incidentType", "HEALTH_EMERGENCY");
+		alarmMap.put("incidentId", 200L);
+		alarmMap.put("incidentDescription", "심박수 비정상 증가");
+		alarmMap.put("latitude", 37.5651);
+		alarmMap.put("longitude", 126.9895);
+		alarmMap.put("imageUrl", null);
+		alarmMap.put("createdAt", LocalDateTime.now());
 
-		Page<Alarm> alarmPage = new PageImpl<>(alarms, PageRequest.of(0, 10), 1);
-		PagedResponse<Alarm> pagedResponse = PagedResponse.of(alarmPage);
+		List<Map<String, Object>> alarmMaps = List.of(alarmMap);
+		Page<Map<String, Object>> alarmPage = new PageImpl<>(alarmMaps, PageRequest.of(0, 10), 1);
+		PagedResponse<Map<String, Object>> pagedResponse = PagedResponse.of(alarmPage);
 		Mockito.when(alarmService.getAlarmsForAdmin(eq(0), eq(10), eq(3))).thenReturn(pagedResponse);
 
 		// when & then
@@ -138,6 +142,7 @@ class AlarmControllerTest {
 			.andExpect(jsonPath("$.status").value("success"))
 			.andExpect(jsonPath("$.data.content").isArray())
 			.andExpect(jsonPath("$.data.content[0].workerId").value(2L))
+			.andExpect(jsonPath("$.data.content[0].workerName").value("홍길동"))
 			.andExpect(jsonPath("$.data.content[0].incidentType").value("HEALTH_EMERGENCY"))
 			.andExpect(jsonPath("$.data.totalElements").value(1));
 
@@ -207,7 +212,7 @@ class AlarmControllerTest {
 	@DisplayName("관리자 API - hours 파라미터 범위 테스트")
 	void adminHoursParameterTest() throws Exception {
 		// given
-		PagedResponse<Alarm> mockResponse = PagedResponse.of(
+		PagedResponse<Map<String, Object>> mockResponse = PagedResponse.of(
 			new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
 		when(alarmService.getAlarmsForAdmin(eq(0), eq(10), eq(168))).thenReturn(mockResponse);
 

--- a/alarm/src/test/java/com/iroom/alarm/service/AlarmServiceTest.java
+++ b/alarm/src/test/java/com/iroom/alarm/service/AlarmServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -129,13 +130,17 @@ class AlarmServiceTest {
 		Page<Alarm> alarmPage = new PageImpl<>(List.of(alarm), pageable, 1);
 		when(alarmRepository.findByOccurredAtAfterOrderByOccurredAtDesc(any(LocalDateTime.class), eq(pageable)))
 			.thenReturn(alarmPage);
+		when(workerReadModelRepository.findById(1L)).thenReturn(Optional.of(workerReadModel));
 
 		// when
-		PagedResponse<Alarm> result = alarmService.getAlarmsForAdmin(0, 10, 3);
+		PagedResponse<Map<String, Object>> result = alarmService.getAlarmsForAdmin(0, 10, 3);
 
 		// then
 		assertThat(result.content()).hasSize(1);
-		assertThat(result.content().get(0).getIncidentId()).isEqualTo(101L);
+		Map<String, Object> alarmMap = result.content().get(0);
+		assertThat(alarmMap.get("workerId")).isEqualTo(1L);
+		assertThat(alarmMap.get("workerName")).isEqualTo("테스트 근로자");
+		assertThat(alarmMap.get("incidentId")).isEqualTo(101L);
 	}
 
 	@Test

--- a/frontend/src/components/AlarmModal.js
+++ b/frontend/src/components/AlarmModal.js
@@ -116,7 +116,7 @@ const AlarmModal = ({ isOpen, onClose }) => {
                                         <div className={styles.alarmContent}>
                                             <p className={styles.alarmTitle}>{alarm.title}</p>
                                             <p className={styles.alarmDesc}>{alarm.description}</p>
-                                            <p className={styles.alarmMeta}>작업자 ID: {alarm.workerId}</p>
+                                            <p className={styles.alarmMeta}>작업자: {alarm.workerName || "알 수 없음"}</p>
                                         </div>
                                         <span className={styles.alarmTime}>{alarm.time}</span>
                                     </div>

--- a/frontend/src/components/AlarmModal.js
+++ b/frontend/src/components/AlarmModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styles from '../styles/AlarmModal.module.css';
 import { alarmAPI } from '../api/api';
 import { useAlarmData } from '../hooks/useAlarmData';
@@ -18,7 +18,7 @@ const AlarmModal = ({ isOpen, onClose }) => {
 
 
     // 알림 목록 로드
-    const loadAlarms = async (page = 0, hours = pagination.hours) => {
+    const loadAlarms = useCallback(async (page = 0, hours = pagination.hours) => {
         setLoading(true);
         try {
             const response = await alarmAPI.getAlarmsForAdmin({
@@ -43,7 +43,7 @@ const AlarmModal = ({ isOpen, onClose }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [pagination.hours, pagination.size, transformAlarmData]);
 
     // 모달이 열릴 때 데이터 로드
     useEffect(() => {

--- a/frontend/src/components/AlarmModal.js
+++ b/frontend/src/components/AlarmModal.js
@@ -50,7 +50,7 @@ const AlarmModal = ({ isOpen, onClose }) => {
         if (isOpen) {
             loadAlarms(0).catch(console.error);
         }
-    }, [isOpen]);
+    }, [isOpen, loadAlarms]);
 
     // 페이지 변경
     const handlePageChange = (newPage) => {

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -54,7 +54,7 @@ const Header = () => {
         const handleNewAlarm = (data) => {
             const newNotification = createNotificationFromWebSocket(data);
             
-            setNotifications(prev => [newNotification, ...prev.slice(0, 49)]); // 최대 50개 유지
+            setNotifications(prev => [newNotification, ...prev.slice(0, 7)]); // 최대 8개 유지
             
             // 토스트 알림 표시
             window.dispatchEvent(new CustomEvent('showNotificationToast', { 

--- a/frontend/src/components/notifications/NotificationToast.js
+++ b/frontend/src/components/notifications/NotificationToast.js
@@ -22,7 +22,7 @@ const NotificationToast = ({
 
             return () => clearTimeout(timer);
         }
-    }, [notification, duration]);
+    }, [notification, duration, handleClose]);
 
     // CSS 애니메이션을 위한 스타일 주입
     useEffect(() => {

--- a/frontend/src/hooks/useAlarmData.js
+++ b/frontend/src/hooks/useAlarmData.js
@@ -92,6 +92,7 @@ export const useAlarmData = () => {
             time: getTimeAgo(alarm.createdAt),
             timestamp: alarm.createdAt,
             workerId: alarm.workerId,
+            workerName: alarm.workerName,
             originalData: alarm
         };
     }, [getAlertTypeFromData, convertToDashboardType, getAlertTitle, getTimeAgo]);

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useCallback} from 'react';
 import styles from '../styles/Dashboard.module.css';
 import stompService from '../services/stompService';
 import {authUtils} from '../utils/auth';
@@ -85,7 +85,7 @@ const DashboardPage = () => {
 
 
     // API로부터 알람 목록 로드
-    const loadAlarms = async () => {
+    const loadAlarms = useCallback(async () => {
         setAlertsLoading(true);
         try {
             const response = await alarmAPI.getAlarmsForAdmin({
@@ -102,7 +102,7 @@ const DashboardPage = () => {
         } finally {
             setAlertsLoading(false);
         }
-    };
+    }, [alertsPagination.page, alertsPagination.size, alertsPagination.hours, transformAlarmData]);
 
     // 웹소켓 연결 및 실시간 데이터 처리
     useEffect(() => {
@@ -150,7 +150,7 @@ const DashboardPage = () => {
         return () => {
             stompService.off('alarm', handleNewAlarm);
         };
-    }, []);
+    }, [convertToDashboardType, getAlertTitle, getAlertTypeFromData]);
 
     // 시간 업데이트 (1분마다 상대시간 갱신)
     useEffect(() => {
@@ -164,12 +164,12 @@ const DashboardPage = () => {
         }, 60000); // 1분마다 업데이트
 
         return () => clearInterval(timer);
-    }, []);
+    }, [getTimeAgo]);
 
     // 컴포넌트 마운트 시 데이터 로드
     useEffect(() => {
         loadAlarms().catch(console.error);
-    }, []);
+    }, [loadAlarms]);
 
     return (
         <div className={styles.page}>

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -276,6 +276,7 @@ const DashboardPage = () => {
                                     </div>
                                     <div className={styles.alertContent}>
                                         <p className={styles.alertTitle}>{alert.title}</p>
+                                        <p className={styles.alertWorker}>작업자: {alert.workerName || "알 수 없음"}</p>
                                         <p className={styles.alertDesc}>{alert.description}</p>
                                     </div>
                                     <span className={styles.alertTime}>{alert.time}</span>

--- a/frontend/src/pages/MonitoringPage.js
+++ b/frontend/src/pages/MonitoringPage.js
@@ -340,6 +340,7 @@ const MonitoringPage = () => {
                     time: getTimeAgo(alarm.createdAt),
                     timestamp: alarm.createdAt,
                     workerId: alarm.workerId,
+                    workerName: alarm.workerName,
                     originalData: alarm
                 };
             }) || [];
@@ -681,6 +682,7 @@ const MonitoringPage = () => {
                                         </div>
                                         <div className={styles.alertContent}>
                                             <p className={styles.alertTitle}>{alert.title}</p>
+                                            <p className={styles.alertWorker}>작업자: {alert.workerName || "알 수 없음"}</p>
                                             <p className={styles.alertDesc}>{alert.description}</p>
                                         </div>
                                         <span className={styles.alertTime}>{alert.time}</span>

--- a/frontend/src/pages/MonitoringPage.js
+++ b/frontend/src/pages/MonitoringPage.js
@@ -134,12 +134,7 @@ const MonitoringPage = () => {
 
             const data = response.data || response;
             const zones = data.content || [];
-            
-            console.log(`MonitoringPage - Blueprint ${blueprintId}의 위험구역 조회 결과:`, {
-                총개수: zones.length,
-                위험구역들: zones.map(z => ({ id: z.id, name: z.name, lat: z.latitude, lon: z.longitude }))
-            });
-            
+
             // 위험구역을 화면에 표시하기 위한 형태로 변환
             const formattedZones = zones
                 .map(zone => {
@@ -150,15 +145,7 @@ const MonitoringPage = () => {
                     // 중심점 기준으로 박스 위치 계산
                     const boxX = canvasPosition.x - canvasSize.width / 2;
                     const boxY = canvasPosition.y - canvasSize.height / 2;
-                    
-                    console.log(`위험구역 ${zone.id} 변환:`, {
-                        GPS: { lat: zone.latitude, lon: zone.longitude },
-                        캔버스중심: canvasPosition,
-                        박스크기: canvasSize,
-                        최종박스: { x: boxX, y: boxY, width: canvasSize.width, height: canvasSize.height },
-                        도면내부여부: isInsideBlueprint(canvasPosition.x, canvasPosition.y)
-                    });
-                    
+
                     return {
                         id: zone.id,
                         x: boxX,
@@ -181,14 +168,7 @@ const MonitoringPage = () => {
                     }
                     return true;
                 });
-            
-            console.log(`MonitoringPage - 필터링 후 최종 위험구역:`, {
-                필터링전개수: zones.length,
-                필터링후개수: formattedZones.length,
-                제거된개수: zones.length - formattedZones.length,
-                최종위험구역들: formattedZones.map(z => ({ id: z.id, name: z.name, x: z.x, y: z.y, isInside: z.isInside }))
-            });
-            
+
             setDangerZones(formattedZones);
         } catch (error) {
             console.error('위험구역 데이터 조회 실패:', error);
@@ -265,12 +245,6 @@ const MonitoringPage = () => {
             return { width: 5, height: 5 }; // 기본값
         }
 
-        console.log('박스 크기 변환:', {
-            입력크기: { width: widthMeters, height: heightMeters },
-            도면크기: { width: currentBlueprint.width, height: currentBlueprint.height },
-            단위: '미터'
-        });
-
         // Blueprint의 width, height가 픽셀이면 실제 건물 크기로 가정
         // 예: 1920x1080 픽셀 → 192m x 108m 건물로 가정 (1픽셀 = 0.1m)
         let realBuildingWidth, realBuildingHeight;
@@ -319,7 +293,7 @@ const MonitoringPage = () => {
 
 
     // API로부터 알람 목록 로드
-    const loadAlarms = async () => {
+    const loadAlarms = useCallback(async () => {
         setAlertsLoading(true);
         try {
             const response = await alarmAPI.getAlarmsForAdmin({
@@ -351,7 +325,7 @@ const MonitoringPage = () => {
         } finally {
             setAlertsLoading(false);
         }
-    };
+    }, [alertsPagination, getAlertTypeFromData, convertToDashboardType, getAlertTitle, getTimeAgo]);
 
     // 웹소켓 연결 및 실시간 데이터 처리
     useEffect(() => {
@@ -392,7 +366,9 @@ const MonitoringPage = () => {
 
         // 웹소켓 연결
         if (!stompService.isConnected()) {
-            connectWebSocket();
+            connectWebSocket().catch(error => {
+                console.error('웹소켓 연결 실패:', error);
+            });
         }
 
         // 클린업
@@ -417,15 +393,21 @@ const MonitoringPage = () => {
 
     // 컴포넌트 마운트 시 데이터 로드
     useEffect(() => {
-        loadAlarms();
-        fetchAvailableBlueprints();
-    }, [alertsPagination.page, alertsPagination.size, alertsPagination.hours, fetchAvailableBlueprints]);
+        loadAlarms().catch(error => {
+            console.error('알람 로드 실패:', error);
+        });
+        fetchAvailableBlueprints().catch(error => {
+            console.error('도면 목록 로드 실패:', error);
+        });
+    }, [loadAlarms, fetchAvailableBlueprints]);
 
     // 초기 도면 자동 선택 (첫 번째 도면)
     useEffect(() => {
         if (availableBlueprints.length > 0 && !currentBlueprint) {
             const firstBlueprint = availableBlueprints[0];
-            selectBlueprint(firstBlueprint.id.toString());
+            selectBlueprint(firstBlueprint.id.toString()).catch(error => {
+                console.error('초기 도면 선택 실패:', error);
+            });
         }
     }, [availableBlueprints, currentBlueprint, selectBlueprint]);
 

--- a/frontend/src/pages/ReportPage.js
+++ b/frontend/src/pages/ReportPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styles from '../styles/Report.module.css';
 // import { reportAPI } from '../api/api'; // API 연동 시 사용
 
@@ -88,13 +88,8 @@ const ReportPage = () => {
         complianceRate: 98
     });
 
-    // 컴포넌트 마운트 시 데이터 로드
-    useEffect(() => {
-        fetchReports();
-    }, [currentPage]);
-
     // 리포트 목록 조회
-    const fetchReports = async () => {
+    const fetchReports = useCallback(async () => {
         try {
             // API 호출 로직
             // const response = await reportAPI.getReports({
@@ -108,7 +103,12 @@ const ReportPage = () => {
         } catch (error) {
             console.error('리포트 데이터 조회 실패:', error);
         }
-    };
+    }, [currentPage, pageSize]);
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        fetchReports();
+    }, [fetchReports]);
 
     // 폼 입력 핸들러
     const handleFormChange = (field, value) => {

--- a/frontend/src/pages/WorkerDetailPage.js
+++ b/frontend/src/pages/WorkerDetailPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { userAPI, managementAPI } from '../api/api';
 import EducationAddModal from '../components/EducationAddModal';
@@ -31,7 +31,7 @@ const WorkerDetailPage = () => {
     const [attendanceError, setAttendanceError] = useState(null);
 
     // 출입현황 조회 함수
-    const fetchWorkerAttendance = async () => {
+    const fetchWorkerAttendance = useCallback(async () => {
         setAttendanceLoading(true);
         setAttendanceError(null);
 
@@ -51,10 +51,10 @@ const WorkerDetailPage = () => {
         } finally {
             setAttendanceLoading(false);
         }
-    };
+    }, [workerId]);
 
     // 교육이력 조회 함수
-    const fetchWorkerEducation = async (page = 0) => {
+    const fetchWorkerEducation = useCallback(async (page = 0) => {
         setEducationLoading(true);
         setEducationError(null);
 
@@ -70,7 +70,7 @@ const WorkerDetailPage = () => {
         } finally {
             setEducationLoading(false);
         }
-    };
+    }, [workerId, pageSize]);
 
     useEffect(() => {
         const fetchWorkerDetail = async () => {
@@ -92,7 +92,7 @@ const WorkerDetailPage = () => {
                 await fetchWorkerAttendance();
             })();
         }
-    }, [workerId]);
+    }, [workerId, fetchWorkerAttendance, fetchWorkerEducation]);
 
     const handleBackClick = () => {
         navigate('/worker');

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -297,9 +297,16 @@
     margin: 0 0 2px 0;
 }
 
-.alertDesc {
-    font-size: 12px;
+.alertWorker {
+    font-size: 11px;
     color: #6B7280;
+    margin: 0 0 2px 0;
+    font-weight: 600;
+}
+
+.alertDesc {
+    font-size: 11px;
+    color: #9CA3AF;
     margin: 0;
 }
 

--- a/frontend/src/styles/Monitoring.module.css
+++ b/frontend/src/styles/Monitoring.module.css
@@ -411,9 +411,16 @@
     margin: 0 0 2px 0;
 }
 
-.alertDesc {
-    font-size: 12px;
+.alertWorker {
+    font-size: 11px;
     color: #6B7280;
+    margin: 0 0 2px 0;
+    font-weight: 600;
+}
+
+.alertDesc {
+    font-size: 11px;
+    color: #9CA3AF;
     margin: 0;
 }
 

--- a/user/src/main/java/com/iroom/user/worker/service/WorkerService.java
+++ b/user/src/main/java/com/iroom/user/worker/service/WorkerService.java
@@ -128,7 +128,7 @@ public class WorkerService {
 			workerPage = workerRepository.findAll(pageable);
 		}
 
-		Page<WorkerInfoResponse> responsePage = workerPage.map(WorkerInfoResponse::new);
+		Page<WorkerInfoResponse> responsePage = workerPage.map(WorkerInfoResponse::maskedFrom);
 
 		return PagedResponse.of(responsePage);
 	}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---

## 변경 사항 
- Alarm 서비스에서 관리자 ID를 기반으로 `worker_ReadModel`의 근로자 이름을 매핑하여 UI에 표시하도록 수정
- 개인정보 마스킹 처리 적용
---
## 테스트 결과
<img width="1859" height="1346" alt="image" src="https://github.com/user-attachments/assets/e5506c31-8fe0-412f-8f18-72bbc79aee38" />
<img width="2509" height="1354" alt="image" src="https://github.com/user-attachments/assets/9837d705-2765-4c0e-9301-3d7c75f2d8f9" />
<img width="2123" height="1283" alt="image" src="https://github.com/user-attachments/assets/20f57769-3f53-41fb-9cac-1e4c5677b21d" />

---
## 현재 미완성 된 부분 
- 위험구역 캔버스 좌표 매핑 검증
- 대시보드 페이지 구현
- 실시간 모니터링 페이지 구현
- 리포트 페이지 구현